### PR TITLE
Fix Codecov reporting, restore Python 3.11 support, and update README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: "pip"
       - name: Install dependencies
         run: pip install ruff
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: "pip"
       - name: Install dependencies
         run: pip install ruff
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: "pip"
       - name: Install dependencies
         run: |
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -74,7 +74,7 @@ jobs:
           pip install .[dev]
       - name: Run Unit Tests
         run: |
-          pytest -vv tests/test_center.py tests/test_simple_detector.py tests/test_simple_linker.py tests/test_tracks.py
+          pytest -vv
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -104,3 +104,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           pytest -vv tests/test_integration.py --run-all
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # PyStormTracker
 
-[![DOI](https://zenodo.org/badge/36328800.svg)](https://doi.org/10.5281/zenodo.18764813)
-[![PyPI version](https://img.shields.io/pypi/v/PyStormTracker)](https://pypi.org/project/PyStormTracker/)
-[![Docker](https://img.shields.io/badge/docker-xddd%2Fpystormtracker-blue?logo=docker)](https://hub.docker.com/r/xddd/pystormtracker)
-[![GHCR](https://img.shields.io/badge/ghcr.io-XDDD%2Fpystormtracker-blue?logo=github)](https://github.com/orgs/XDDD/packages/container/package/pystormtracker)
 [![CI](https://github.com/mwyau/PyStormTracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mwyau/PyStormTracker/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/mwyau/PyStormTracker/graph/badge.svg?token=JmTabGA3cq)](https://codecov.io/github/mwyau/PyStormTracker)
-![License](https://img.shields.io/pypi/l/PyStormTracker)
+[![PyPI version](https://img.shields.io/pypi/v/PyStormTracker)](https://pypi.org/project/PyStormTracker/)
 ![Python versions](https://img.shields.io/pypi/pyversions/PyStormTracker)
+![License](https://img.shields.io/pypi/l/PyStormTracker)
+[![DOI](https://zenodo.org/badge/36328800.svg)](https://doi.org/10.5281/zenodo.18764813)
+[![Docker](https://img.shields.io/badge/docker-xddd%2Fpystormtracker-blue?logo=docker)](https://hub.docker.com/r/xddd/pystormtracker)
+[![GHCR](https://img.shields.io/badge/ghcr.io-XDDD%2Fpystormtracker-blue?logo=github)](https://github.com/orgs/XDDD/packages/container/package/pystormtracker)
 
 PyStormTracker provides the implementation of the "Simple Tracker" algorithm used for cyclone trajectory analysis in **Yau and Chang (2020)**. It was originally developed at the **National Center for Atmospheric Research (NCAR)** as part of the **2015 Summer Internships in Parallel Computational Science (SIParCS)** program, utilizing a task-parallel strategy with temporal decomposition and a tree reduction algorithm to process large climate datasets.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ stormtracker -i era5_msl_2.5x2.5.nc -v msl -o my_tracks
 | `--input` | `-i` | **Required.** Path to the input NetCDF file. |
 | `--var` | `-v` | **Required.** Variable name to track (e.g., `msl`, `vo`). |
 | `--output` | `-o` | **Required.** Path to the output track file (appends `.txt` if missing). |
-| `--num" | `-n` | Number of time steps to process. |
+| `--num` | `-n` | Number of time steps to process. |
 | `--mode` | `-m` | `min` (default) for low pressure, `max` for vorticity/high pressure. |
 | `--backend` | `-b` | `dask` (default), `serial`, or `mpi`. |
 | `--workers` | `-w` | Number of Dask workers (defaults to CPU core count). |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![DOI](https://zenodo.org/badge/36328800.svg)](https://doi.org/10.5281/zenodo.18764813)
 [![PyPI version](https://img.shields.io/pypi/v/PyStormTracker)](https://pypi.org/project/PyStormTracker/)
-[![Docker Image Size](https://img.shields.io/docker/image-size/xddd/pystormtracker/latest?logo=docker)](https://hub.docker.com/r/xddd/pystormtracker)
+[![Docker](https://img.shields.io/docker/v/xddd/pystormtracker/latest?label=docker&logo=docker)](https://hub.docker.com/r/xddd/pystormtracker)
 [![GHCR](https://img.shields.io/badge/ghcr.io-xddd%2Fpystormtracker-blue?logo=github)](https://github.com/mwyau/PyStormTracker/pkgs/container/pystormtracker)
 [![CI](https://github.com/mwyau/PyStormTracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mwyau/PyStormTracker/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/mwyau/PyStormTracker/graph/badge.svg?token=JmTabGA3cq)](https://codecov.io/github/mwyau/PyStormTracker)
@@ -13,7 +13,7 @@ PyStormTracker provides the implementation of the "Simple Tracker" algorithm use
 
 ## Features
 
-- **Modern Python Support**: Strictly targets **Python 3.12+** with comprehensive type hints and 100% strict `mypy` compliance.
+- **Modern Python Support**: Strictly targets **Python 3.11+** with comprehensive type hints and 100% strict `mypy` compliance.
 - **Xarray Integrated**: Fully migrated to `xarray` and `h5netcdf` for robust, high-performance coordinate-aware I/O and lazy data loading.
 - **Parallel Backends**:
   - **Dask (Default)**: Automatically scales to all available CPU cores on local machines.
@@ -35,7 +35,7 @@ PyStormTracker treats meteorological fields as 2D images and leverages `scipy.nd
 ## Installation
 
 ### Prerequisites
-- Python 3.12+
+- Python 3.11+
 - (Optional) OpenMPI for MPI support.
 
 ### From PyPI (Recommended)
@@ -81,7 +81,7 @@ stormtracker -i era5_msl_2.5x2.5.nc -v msl -o my_tracks
 ### Setup
 It is recommended to use a virtual environment or conda for development:
 ```bash
-conda create -n pst python=3.12
+conda create -n pst python=3.11
 conda activate pst
 pip install -e .[dev]
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/36328800.svg)](https://doi.org/10.5281/zenodo.18764813)
 [![PyPI version](https://img.shields.io/pypi/v/PyStormTracker)](https://pypi.org/project/PyStormTracker/)
 [![Docker](https://img.shields.io/badge/docker-xddd%2Fpystormtracker-blue?logo=docker)](https://hub.docker.com/r/xddd/pystormtracker)
-[![GHCR](https://img.shields.io/badge/ghcr.io-xddd%2Fpystormtracker-blue?logo=github)](https://github.com/mwyau/PyStormTracker/pkgs/container/pystormtracker)
+[![GHCR](https://img.shields.io/badge/ghcr.io-XDDD%2Fpystormtracker-blue?logo=github)](https://github.com/orgs/XDDD/packages/container/package/pystormtracker)
 [![CI](https://github.com/mwyau/PyStormTracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mwyau/PyStormTracker/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/mwyau/PyStormTracker/graph/badge.svg?token=JmTabGA3cq)](https://codecov.io/github/mwyau/PyStormTracker)
 ![License](https://img.shields.io/pypi/l/PyStormTracker)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![DOI](https://zenodo.org/badge/36328800.svg)](https://doi.org/10.5281/zenodo.18764813)
 [![PyPI version](https://img.shields.io/pypi/v/PyStormTracker)](https://pypi.org/project/PyStormTracker/)
-[![Docker](https://img.shields.io/docker/v/xddd/pystormtracker/latest?label=docker&logo=docker)](https://hub.docker.com/r/xddd/pystormtracker)
+[![Docker](https://img.shields.io/badge/docker-xddd%2Fpystormtracker-blue?logo=docker)](https://hub.docker.com/r/xddd/pystormtracker)
 [![GHCR](https://img.shields.io/badge/ghcr.io-xddd%2Fpystormtracker-blue?logo=github)](https://github.com/mwyau/PyStormTracker/pkgs/container/pystormtracker)
 [![CI](https://github.com/mwyau/PyStormTracker/actions/workflows/ci.yml/badge.svg)](https://github.com/mwyau/PyStormTracker/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/mwyau/PyStormTracker/graph/badge.svg?token=JmTabGA3cq)](https://codecov.io/github/mwyau/PyStormTracker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 description = "A Parallel Object-Oriented Cyclone Tracker in Python"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 authors = [
     { name = "Albert M. W. Yau", email = "albert@mwyau.com" }
 ]
@@ -20,6 +20,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -63,7 +64,7 @@ exclude = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py311"
 line-length = 88
 
 [tool.ruff.lint]
@@ -79,7 +80,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
@@ -93,7 +94,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "8.0"
-addopts = "-ra -q --cov=src/pystormtracker --cov-report=term-missing --cov-report=xml"
+addopts = "-ra -q --cov=pystormtracker --cov-report=term-missing --cov-report=xml"
 testpaths = [
     "tests",
 ]
@@ -102,8 +103,14 @@ markers = [
 ]
 
 [tool.coverage.run]
-source = ["src/pystormtracker"]
+source = ["pystormtracker"]
 omit = ["tests/*", "**/__init__.py"]
+
+[tool.coverage.paths]
+source = [
+    "src/pystormtracker",
+    "**/site-packages/pystormtracker",
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/src/pystormtracker/models/center.py
+++ b/src/pystormtracker/models/center.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from typing import TypeAlias
 
 import numpy as np
 
@@ -56,4 +57,4 @@ class Center:
         return self.R * dlon * self.DEGTORAD * math.cos(avglat * self.DEGTORAD)
 
 
-type DetectionResult = list[list[Center]]
+DetectionResult: TypeAlias = list[list[Center]]


### PR DESCRIPTION
This PR resolves the issue where Codecov reported 0% coverage and restores support for Python 3.11.

### Changes:
- **Codecov & CI/CD Fixes**: 
  - Corrected source path mapping in `pyproject.toml` to resolve the **0% coverage** issue.
  - Added Codecov upload steps to both unit and integration tests.
  - Rearranged README badges for better logical grouping.
- **Python 3.11 Compatibility**:
  - Restored support for **Python 3.11** by updating `requires-python` and the CI matrix.
  - Refactored Python 3.12+ `type` aliases to use `typing.TypeAlias` in `src/pystormtracker/models/center.py`.
- **Documentation Updates**:
  - Corrected the DockerHub and GHCR badge links.
  - Updated Python version requirements in the installation and development sections.