### PR TITLE
Add Read the Docs documentation support

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.14"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev
+
+sphinx:
+  configuration: docs/conf.py

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![DOI](https://zenodo.org/badge/36328800.svg)](https://doi.org/10.5281/zenodo.18764813)
 [![Docker](https://img.shields.io/badge/docker-xddd%2Fpystormtracker-blue?logo=docker)](https://hub.docker.com/r/xddd/pystormtracker)
 [![GHCR](https://img.shields.io/badge/ghcr.io-XDDD%2Fpystormtracker-blue?logo=github)](https://github.com/orgs/XDDD/packages/container/package/pystormtracker)
+[![Documentation Status](https://readthedocs.org/projects/pystormtracker/badge/?version=latest)](https://pystormtracker.readthedocs.io/en/latest/?badge=latest)
 
 PyStormTracker provides the implementation of the "Simple Tracker" algorithm used for cyclone trajectory analysis in **Yau and Chang (2020)**. It was originally developed at the **National Center for Atmospheric Research (NCAR)** as part of the **2015 Summer Internships in Parallel Computational Science (SIParCS)** program, utilizing a task-parallel strategy with temporal decomposition and a tree reduction algorithm to process large climate datasets.
 
@@ -31,6 +32,10 @@ PyStormTracker treats meteorological fields as 2D images and leverages `scipy.nd
 - **Intensity & Refinement**: Applies the **Laplacian operator** (`laplace`) to measure the "sharpness" of the field at each detected center point. This is used to resolve duplicates and ensure only the most physically intense point is kept when multiple adjacent pixels are flagged.
 - **Spherical Continuity**: Utilizes `mode='wrap'` for all filters to correctly handle periodic boundaries across the Prime Meridian, enabling seamless tracking across the entire globe.
 - **Heuristic Linking**: Implements a nearest-neighbor linking strategy to connect detected centers into trajectories across successive time steps.
+
+## Documentation
+
+Full documentation, including API references and advanced usage examples, is available at [pystormtracker.readthedocs.io](https://pystormtracker.readthedocs.io/).
 
 ## Installation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,31 @@
+# Configuration file for the Sphinx documentation builder.
+
+import os
+import sys
+from datetime import datetime
+
+# -- Project information -----------------------------------------------------
+project = "PyStormTracker"
+copyright = f"{datetime.now().year}, Albert M. W. Yau"
+author = "Albert M. W. Yau"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Options for HTML output -------------------------------------------------
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+
+# -- MyST Parser configuration -----------------------------------------------
+myst_enable_extensions = [
+    "colon_fences",
+    "deflist",
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,5 @@
 # Configuration file for the Sphinx documentation builder.
 
-import os
-import sys
 from datetime import datetime
 
 # -- Project information -----------------------------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to PyStormTracker's documentation!
+
+```{include} ../README.md
+:start-after: "# PyStormTracker"
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Contents:
+
+```
+
+## Indices and tables
+
+* {ref}`genindex`
+* {ref}`modindex`
+* {ref}`search`

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,10 @@
 
 ```
 
+## Resources
+
+- [IMILAST Intercomparison Protocol (PDF)](IntercomparisonProtocol.pdf)
+
 ## Indices and tables
 
 * {ref}`genindex`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dev = [
     "pre-commit>=3.7.0",
     "mpi4py>=3.1.5",
     "pandas>=2.2.0",
+    "sphinx>=7.2.0",
+    "sphinx-rtd-theme>=2.0.0",
+    "myst-parser>=2.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
This PR adds Sphinx documentation scaffolding and Read the Docs (RTD) integration.

### Changes:
- Added Sphinx configuration in `docs/` with the **MyST parser** (to support Markdown).
- Configured `docs/index.md` to automatically include and display the root `README.md`.
- Added `.readthedocs.yaml` configured for **Ubuntu 24.04** and **Python 3.14**.
- Updated `pyproject.toml` dev dependencies to include `sphinx`, `sphinx-rtd-theme`, and `myst-parser`.
- Added an RTD badge and a Documentation section to the `README.md`.