### PR TITLE
Optimize Read the Docs build with dedicated docs group and uv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,10 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.14"
+  jobs:
+    post_create_environment:
+      - pip install uv
+      - uv sync --group docs
 
 sphinx:
   configuration: docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,14 @@ dev = [
     "pytest>=8.1.1",
     "pytest-cov>=5.0.0",
     "pre-commit>=4.0.0",
-    "sphinx>=7.2.0",
-    "sphinx-rtd-theme>=2.0.0",
-    "myst-parser>=2.0.0",
     "pooch>=1.8.0",
     "pystormtracker[mpi,grib]",
 ]
-
+docs = [
+    "sphinx>=7.2.0",
+    "sphinx-rtd-theme>=2.0.0",
+    "myst-parser>=2.0.0",
+]
 
 [tool.ruff]
 target-version = "py311"

--- a/uv.lock
+++ b/uv.lock
@@ -1243,13 +1243,15 @@ mpi = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
-    { name = "myst-parser" },
     { name = "pooch" },
     { name = "pre-commit" },
     { name = "pystormtracker", extra = ["grib", "mpi"] },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+]
+docs = [
+    { name = "myst-parser" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-rtd-theme" },
@@ -1272,13 +1274,15 @@ provides-extras = ["mpi", "grib"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.15.0" },
-    { name = "myst-parser", specifier = ">=2.0.0" },
     { name = "pooch", specifier = ">=1.8.0" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pystormtracker", extras = ["mpi", "grib"] },
     { name = "pytest", specifier = ">=8.1.1" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "ruff", specifier = ">=0.9.0" },
+]
+docs = [
+    { name = "myst-parser", specifier = ">=2.0.0" },
     { name = "sphinx", specifier = ">=7.2.0" },
     { name = "sphinx-rtd-theme", specifier = ">=2.0.0" },
 ]


### PR DESCRIPTION
This PR improves the documentation build process on Read the Docs.

### Changes:
- **Dependency Refactoring**: Moved documentation-related dependencies (`sphinx`, `myst-parser`, etc.) from the `dev` group to a dedicated `docs` dependency group in `pyproject.toml`.
- **RTD Optimization**: Updated `.readthedocs.yaml` to install `uv` and use it to synchronize only the `docs` group, ensuring faster and more reliable environment setup.
- **Improved Isolation**: Decoupled documentation tools from general development and testing tools.