### PR TITLE
Fix Read the Docs build environment and dependency resolution

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
   jobs:
     post_create_environment:
       - pip install uv
-      - uv sync --group docs
+      - uv pip install --system .[docs]
 
 sphinx:
   configuration: docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ mpi = [
 grib = [
     "cfgrib>=0.9.15",
 ]
+docs = [
+    "sphinx>=7.2.0",
+    "sphinx-rtd-theme>=2.0.0",
+    "myst-parser>=2.0.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pystormtracker"]
@@ -60,12 +65,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "pre-commit>=4.0.0",
     "pooch>=1.8.0",
-    "pystormtracker[mpi,grib]",
-]
-docs = [
-    "sphinx>=7.2.0",
-    "sphinx-rtd-theme>=2.0.0",
-    "myst-parser>=2.0.0",
+    "pystormtracker[mpi,grib,docs]",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1233,6 +1233,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+docs = [
+    { name = "myst-parser" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-rtd-theme" },
+]
 grib = [
     { name = "cfgrib" },
 ]
@@ -1245,16 +1251,10 @@ dev = [
     { name = "mypy" },
     { name = "pooch" },
     { name = "pre-commit" },
-    { name = "pystormtracker", extra = ["grib", "mpi"] },
+    { name = "pystormtracker", extra = ["docs", "grib", "mpi"] },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-]
-docs = [
-    { name = "myst-parser" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-rtd-theme" },
 ]
 
 [package.metadata]
@@ -1265,26 +1265,24 @@ requires-dist = [
     { name = "h5netcdf", specifier = ">=1.0.0" },
     { name = "h5py", specifier = ">=3.0.0" },
     { name = "mpi4py", marker = "extra == 'mpi'", specifier = ">=4.0.0" },
+    { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "numpy", specifier = ">=1.23.0" },
     { name = "scipy", specifier = ">=1.9.0" },
+    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.2.0" },
+    { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "xarray", specifier = ">=2024.9.0" },
 ]
-provides-extras = ["mpi", "grib"]
+provides-extras = ["mpi", "grib", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pooch", specifier = ">=1.8.0" },
     { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "pystormtracker", extras = ["mpi", "grib"] },
+    { name = "pystormtracker", extras = ["mpi", "grib", "docs"] },
     { name = "pytest", specifier = ">=8.1.1" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "ruff", specifier = ">=0.9.0" },
-]
-docs = [
-    { name = "myst-parser", specifier = ">=2.0.0" },
-    { name = "sphinx", specifier = ">=7.2.0" },
-    { name = "sphinx-rtd-theme", specifier = ">=2.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR resolves the `ModuleNotFoundError: No module named 'myst_parser'` and other environment-related failures during the Read the Docs build.

### Changes:
- **Dependency Refactoring**: Moved documentation dependencies from a `dependency-group` back to `optional-dependencies` (extras). Standard extras are more reliably resolved by build tools in restricted environments like RTD.
- **RTD Config Update**: Switched from `uv sync` to `uv pip install --system .[docs]`. This ensures that Sphinx and its extensions are installed directly into the system Python environment that RTD uses to execute the build process.
- **Lockfile Synchronization**: Updated `uv.lock` to match the revised `pyproject.toml` structure.