### PR TITLE
ci(docker): optimize docker publish, build speed, and ci triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,22 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
   push:
     branches:
       - main
       - release/**
     tags:
       - v*
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       packages: write
       id-token: write
@@ -78,8 +79,8 @@ jobs:
         with:
           context: .
           push: true
-          provenance: true
-          sbom: true
+          provenance: false
+          sbom: false
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -98,4 +99,26 @@ jobs:
         with:
           subject-name: ${{ env.GHCR_REPO }}
           subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.GHCR_REPO }}@${{ steps.push.outputs.digest }}
+          artifact-name: sbom.spdx.json
+
+      - name: Attest SBOM (Docker Hub)
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.DOCKER_HUB_REPO }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: 'sbom.spdx.json'
+          push-to-registry: true
+
+      - name: Attest SBOM (GHCR)
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.GHCR_REPO }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: 'sbom.spdx.json'
           push-to-registry: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,21 +99,23 @@ jobs:
         with:
           subject-name: ${{ env.GHCR_REPO }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: false
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
           image: ${{ env.GHCR_REPO }}@${{ steps.push.outputs.digest }}
-          artifact-name: sbom.spdx.json
-          output-file: sbom.spdx.json
+          artifact-name: sbom.cyclonedx.json
+          output-file: sbom.cyclonedx.json
+          output-format: cyclonedx-json
+          args: --exclude-files
 
       - name: Attest SBOM (Docker Hub)
         uses: actions/attest-sbom@v2
         with:
           subject-name: ${{ env.DOCKER_HUB_REPO }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: 'sbom.spdx.json'
+          sbom-path: 'sbom.cyclonedx.json'
           push-to-registry: true
 
       - name: Attest SBOM (GHCR)
@@ -121,5 +123,5 @@ jobs:
         with:
           subject-name: ${{ env.GHCR_REPO }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: 'sbom.spdx.json'
-          push-to-registry: true
+          sbom-path: 'sbom.cyclonedx.json'
+          push-to-registry: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           image: ${{ env.GHCR_REPO }}@${{ steps.push.outputs.digest }}
           artifact-name: sbom.spdx.json
+          output-file: sbom.spdx.json
 
       - name: Attest SBOM (Docker Hub)
         uses: actions/attest-sbom@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DOCKER_HUB_REPO: xddd/pystormtracker
+  DOCKER_HUB_REPO: docker.io/xddd/pystormtracker
   GHCR_REPO: ghcr.io/xddd/pystormtracker
 
 jobs:
@@ -59,7 +59,7 @@ jobs:
             ${{ env.GHCR_REPO }}
           tags: |
             # Always tag with short SHA
-            type=sha,format=short
+            type=sha,format=short,prefix=
             # Tag with 'latest' only for releases
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             # Tag with 'dev' only for main branch

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,18 +104,17 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.GHCR_REPO }}@${{ steps.push.outputs.digest }}
-          artifact-name: sbom.cyclonedx.json
-          output-file: sbom.cyclonedx.json
-          output-format: cyclonedx-json
-          args: --exclude-files
+          path: ./
+          artifact-name: sbom.spdx.json
+          output-file: sbom.spdx.json
+          output-format: spdx-json
 
       - name: Attest SBOM (Docker Hub)
         uses: actions/attest-sbom@v2
         with:
           subject-name: ${{ env.DOCKER_HUB_REPO }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: 'sbom.cyclonedx.json'
+          sbom-path: 'sbom.spdx.json'
           push-to-registry: true
 
       - name: Attest SBOM (GHCR)
@@ -123,5 +122,5 @@ jobs:
         with:
           subject-name: ${{ env.GHCR_REPO }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: 'sbom.cyclonedx.json'
+          sbom-path: 'sbom.spdx.json'
           push-to-registry: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build Stage ---
-FROM python:3.14-slim AS builder
+FROM python:3.13-slim AS builder
 
 # Prevent uv from creating a virtualenv that might be hard to move
 ENV UV_COMPILE_BYTECODE=1 \
@@ -8,40 +8,42 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 WORKDIR /app
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install build dependencies with cache mount for apt
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     libeccodes-dev \
-    gcc \
-    libc6-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # 1. Copy only dependency files for better layer caching.
-# This ensures that we only re-download dependencies if these files change.
 COPY pyproject.toml uv.lock ./
 
 # 2. Install third-party dependencies first (including grib extra).
-# --no-install-workspace allows us to install dependencies without the project source yet.
-RUN uv sync --frozen --no-dev --no-install-workspace --extra grib
+# Use cache mount for uv to persist downloads and build artifacts.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-workspace --extra grib
 
 # 3. Copy only necessary source files for the final installation step.
 COPY src/ ./src/
 COPY README.md ./
 
 # 4. Final installation of the project package itself.
-# This step is very fast because the heavy dependencies are already cached.
-RUN uv sync --frozen --no-dev --extra grib
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --extra grib
 
 
 # --- Runtime Stage ---
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 
 # Install ONLY the runtime shared libraries
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     libeccodes0 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR improves the Docker publishing workflow and CI efficiency.

### Key Changes:
- **Docker Workflow Optimization**: 
  - Fixed Docker Hub registry parsing and short SHA tagging.
  - Disabled redundant default attestations to keep the GHCR UI clean.
  - Switched to source-based SBOM generation (SPDX) to stay within GitHub's 16MB attestation limit.
  - Attestations are now pushed to Docker Hub only (where they are most beneficial for the UI) but are still verifiable via the GitHub API for both registries.
- **Docker Build Speed**:
  - Optimized the `Dockerfile` with Python 3.13-slim and Docker BuildKit cache mounts (`--mount=type=cache`) for `uv` and `apt`.
- **CI Efficiency**:
  - Added `paths` filters to `.github/workflows/ci.yml` so that tests only trigger on changes to source code, tests, or dependency files (`pyproject.toml`, `uv.lock`), saving CI minutes.