### PR TITLE
fix: rename citation title

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: PyStormTracker
+title: mwyau/PyStormTracker
 message: "If you use this software, please cite it as below."
 type: software
 authors:


### PR DESCRIPTION
Renames the citation title in CITATION.cff to mwyau/PyStormTracker for better clarity.