### PR TITLE
ci: orchestrate sequential Docker and PyPI publishing in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,3 +216,10 @@ jobs:
        startsWith(github.ref, 'refs/tags/v'))
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
+
+  pypi-publish:
+    name: pypi-publish
+    needs: [integration-tests]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    uses: ./.github/workflows/python-publish.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - 'Dockerfile'
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:
@@ -113,6 +115,12 @@ jobs:
         if: matrix.python-version == '3.14' && !matrix.min-deps
         run: uv run pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
 
+      - name: Upload coverage reports to Codecov
+        if: matrix.python-version == '3.14' && !matrix.min-deps
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   integration-tests:
     name: integration-tests (Python ${{ matrix.python-version }}, ${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
@@ -158,8 +166,10 @@ jobs:
     name: docker-build
     needs: [integration-tests]
     if: |
-      startsWith(github.ref, 'refs/heads/main') ||
-      startsWith(github.ref, 'refs/heads/release/')
+      github.event_name != 'pull_request' &&
+      (startsWith(github.ref, 'refs/heads/main') ||
+       startsWith(github.ref, 'refs/heads/release/') ||
+       startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -178,20 +188,31 @@ jobs:
           push: false
           load: true
           platforms: linux/amd64
-          tags: "${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }}"
+          tags: "${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }}"
           cache-from: type=gha,scope=docker-build
           cache-to: type=gha,mode=max,scope=docker-build
 
       - name: Smoke test Docker image
         run: |
-          docker run --rm ${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }} --help
+          docker run --rm ${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }} --help
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
         with:
-          image-ref: "${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }}"
+          image-ref: "${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }}"
           format: "table"
           exit-code: "0"
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
+
+  docker-publish:
+    name: docker-publish
+    needs: [docker-build]
+    if: |
+      github.event_name != 'pull_request' &&
+      (startsWith(github.ref, 'refs/heads/main') ||
+       startsWith(github.ref, 'refs/heads/release/') ||
+       startsWith(github.ref, 'refs/tags/v'))
+    uses: ./.github/workflows/docker-publish.yml
+    secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,7 @@
 name: Docker Publish
 
 on:
-  push:
-    branches:
-      - main
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
 
 concurrency:
@@ -13,8 +9,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DOCKER_HUB_REPO: docker.io/${{ vars.DOCKER_IMAGE_NAME }}
-  GHCR_REPO: ghcr.io/${{ vars.DOCKER_IMAGE_NAME }}
+  DOCKER_HUB_REPO: docker.io/${{ github.event_name == 'release' && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
+  GHCR_REPO: ghcr.io/${{ github.event_name == 'release' && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
 
 jobs:
   build-and-push:
@@ -60,17 +56,17 @@ jobs:
             ${{ env.DOCKER_HUB_REPO }}
             ${{ env.GHCR_REPO }}
           tags: |
-            # Always tag with short SHA
-            type=sha,format=short,prefix=
             # Tag with 'edge' only for main branch
-            type=edge,branch=main
-            # Branch tag for all branches except main
-            type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
+            type=edge,branch=main,priority=700
             # Semver tags for releases (includes 'latest')
-            type=semver,pattern=latest
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref_name, 'v0') }}
+            type=semver,pattern=latest,priority=1000
+            type=semver,pattern={{version}},priority=900
+            type=semver,pattern={{major}}.{{minor}},priority=900
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref_name, 'v0') }},priority=900
+            # Branch tag for all branches except main
+            type=ref,event=branch,enable=${{ github.ref_name != 'main' }},priority=600
+            # Always tag with short SHA
+            type=sha,format=short,prefix=,priority=100
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,8 +4,7 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [published]
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,6 +15,7 @@ permissions:
 
 jobs:
   release-build:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Set up uv
@@ -47,6 +48,7 @@ jobs:
           path: dist/
 
   pypi-publish:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs:
       - release-build


### PR DESCRIPTION
This PR refactors the CI/CD pipeline to ensure that Docker and PyPI releases occur sequentially and only after all CI tests (including integration tests) have successfully passed.

### Key Changes:
- **Sequential Orchestration**: Converted `docker-publish.yml` and `python-publish.yml` into reusable workflows (`workflow_call`).
- **CI-Led Deployment**: The main `CI` workflow now orchestrates the publishing jobs, ensuring they depend on the successful completion of the testing phase.
- **Dynamic Namespacing**: Docker publishing now automatically uses `vars.DOCKER_ORG_NAME` for official releases and the repository owner’s namespace for other events.
- **Enhanced Safeguards**: Added `if: github.event_name == "release"` checks to the PyPI workflow to prevent accidental manual triggers and ensure it only runs during intended release events.
- **Tag Support**: Updated Docker build and publish logic to support tag-based triggers (`v*`).
- **Coverage Reporting**: Added Codecov upload step for unit tests to ensure complete coverage tracking.