### PR TITLE
ci: fix workflow permissions for sequential publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,13 @@ jobs:
       (startsWith(github.ref, 'refs/heads/main') ||
        startsWith(github.ref, 'refs/heads/release/') ||
        startsWith(github.ref, 'refs/tags/v'))
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
 
@@ -221,5 +228,9 @@ jobs:
     name: pypi-publish
     needs: [integration-tests]
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/python-publish.yml
     secrets: inherit


### PR DESCRIPTION
This PR adds the necessary permissions to the `docker-publish` and `pypi-publish` jobs in the main CI workflow. 

Reusable workflows inherit permissions from the caller, but if they request more than what the caller provides at the job level, the workflow fails validation. This fix ensures that the publishing jobs have the authority needed to perform Docker and PyPI releases.