### PR TITLE
ci: decouple publish workflows and implement workflow_run triggers with security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,11 +153,6 @@ jobs:
   docker-build:
     name: docker-build
     needs: [ruff-lint, ruff-format, mypy-typecheck, unit-tests, integration-tests]
-    if: |
-      github.event_name != 'pull_request' &&
-      (startsWith(github.ref, 'refs/heads/main') ||
-       startsWith(github.ref, 'refs/heads/release/') ||
-       startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -197,3 +192,18 @@ jobs:
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
 
+  pypi-build:
+    name: pypi-build
+    needs: [ruff-lint, ruff-format, mypy-typecheck, unit-tests, integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Build release distributions
+        run: uv build --wheel --sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,10 @@ jobs:
 
       - name: Smoke test Docker image
         run: |
+          # Test CLI help
           docker run --rm ${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }} --help
+          # Test library import
+          docker run --rm --entrypoint python ${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }} -c "import pystormtracker as pst; print('Import success')"
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.35.0
@@ -193,24 +196,6 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
-
-  docker-publish:
-    name: docker-publish
-    needs: [docker-build]
-    if: |
-      github.event_name != 'pull_request' &&
-      (startsWith(github.ref, 'refs/heads/main') ||
-       startsWith(github.ref, 'refs/heads/release/') ||
-       startsWith(github.ref, 'refs/tags/v'))
-    permissions:
-      actions: read
-      contents: write
-      packages: write
-      id-token: write
-      attestations: write
-      artifact-metadata: write
-    uses: ./.github/workflows/docker-publish.yml
-    secrets: inherit
 
   pypi-publish:
     name: pypi-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,13 +197,3 @@ jobs:
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
 
-  pypi-publish:
-    name: pypi-publish
-    needs: [ruff-lint, ruff-format, mypy-typecheck, unit-tests, integration-tests]
-    if: github.event_name == 'release' && github.event.action == 'published'
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    uses: ./.github/workflows/python-publish.yml
-    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,26 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'Dockerfile'
+      - '.github/workflows/ci.yml'
   push:
     branches:
       - main
       - release/**
     tags:
       - v*
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'Dockerfile'
+      - '.github/workflows/ci.yml'
   release:
     types: [published]
   workflow_dispatch:
@@ -153,6 +167,14 @@ jobs:
   docker-build:
     name: docker-build
     needs: [ruff-lint, ruff-format, mypy-typecheck, unit-tests, integration-tests]
+    # Only run on merges to main, release branches, tags, releases, or manual dispatch
+    if: |
+      github.event_name != 'pull_request' &&
+      (github.ref == 'refs/heads/main' ||
+       startsWith(github.ref, 'refs/heads/release/') ||
+       startsWith(github.ref, 'refs/tags/v') ||
+       github.event_name == 'release' ||
+       github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -195,6 +217,14 @@ jobs:
   pypi-build:
     name: pypi-build
     needs: [ruff-lint, ruff-format, mypy-typecheck, unit-tests, integration-tests]
+    # Only run on merges to main, release branches, tags, releases, or manual dispatch
+    if: |
+      github.event_name != 'pull_request' &&
+      (github.ref == 'refs/heads/main' ||
+       startsWith(github.ref, 'refs/heads/release/') ||
+       startsWith(github.ref, 'refs/tags/v') ||
+       github.event_name == 'release' ||
+       github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,9 @@
 name: Docker Publish
 
 on:
-  workflow_call:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
 
 concurrency:
@@ -9,12 +11,18 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DOCKER_HUB_REPO: docker.io/${{ github.event_name == 'release' && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
-  GHCR_REPO: ghcr.io/${{ github.event_name == 'release' && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
+  # Publish to ORG on release, else to OWNER (personal) for merge to main/manual
+  DOCKER_HUB_REPO: docker.io/${{ (github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'release')) && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
+  GHCR_REPO: ghcr.io/${{ (github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'release')) && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Only run if CI succeeded (for workflow_run) or if it's a release/manual trigger
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.event == 'release')) ||
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch'
     permissions:
       actions: read
       contents: write
@@ -26,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
 
       - name: Set up QEMU
@@ -56,7 +64,7 @@ jobs:
             ${{ env.DOCKER_HUB_REPO }}
             ${{ env.GHCR_REPO }}
           tags: |
-            # Tag with 'edge' only for main branch
+            # Tag with 'edge' only for main branch builds
             type=edge,branch=main,priority=700
             # Semver tags for releases (includes 'latest')
             type=semver,pattern=latest,priority=1000

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,6 +66,8 @@ jobs:
           images: |
             ${{ env.DOCKER_HUB_REPO }}
             ${{ env.GHCR_REPO }}
+          # Fix: Tell the metadata action the real ref, otherwise it defaults to 'main'
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
           tags: |
             # Tag with 'edge' only for main branch builds
             type=edge,branch=main,priority=700

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,10 +18,9 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Only run if CI succeeded (for workflow_run) or if it's a release/manual trigger
+    # Only run if CI succeeded (for workflow_run) or if it's a manual trigger
     if: |
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.event == 'release')) ||
-      github.event_name == 'release' ||
       github.event_name == 'workflow_dispatch'
     permissions:
       actions: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,9 +18,13 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Only run if CI succeeded (for workflow_run) or if it's a manual trigger
+    # Only run if CI succeeded (for workflow_run) or if it's a manual trigger.
+    # Added head_repository check for security in trusted context.
     if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.event == 'release')) ||
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' && 
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.event == 'release')) ||
       github.event_name == 'workflow_dispatch'
     permissions:
       actions: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,7 +4,10 @@
 name: Upload Python Package
 
 on:
-  workflow_call:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,8 +18,15 @@ permissions:
 
 jobs:
   release-build:
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    # Only run if CI succeeded AND it was a release event.
+    # Added head_repository check for security.
+    if: |
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' && 
+       github.event.workflow_run.event == 'release' &&
+       github.event.workflow_run.head_repository.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       id-token: write
@@ -25,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
 
       - name: Set up uv
@@ -48,7 +58,6 @@ jobs:
           path: dist/
 
   pypi-publish:
-    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs:
       - release-build
@@ -66,7 +75,8 @@ jobs:
         id: get_version
         run: |
           # Strips 'v' prefix from tag_name (e.g. v0.2.1 -> 0.2.1)
-          VERSION=${{ github.event.release.tag_name }}
+          # Use head_branch for workflow_run, or ref_name for dispatch
+          VERSION=${{ github.event.workflow_run.head_branch || github.ref_name }}
           echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
 
       - name: Retrieve release distributions

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,7 +7,6 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,11 +21,10 @@ jobs:
     # Only run if CI succeeded AND it was a release event.
     # Added head_repository check for security.
     if: |
-      (github.event_name == 'workflow_run' && 
-       github.event.workflow_run.conclusion == 'success' && 
-       github.event.workflow_run.event == 'release' &&
-       github.event.workflow_run.head_repository.full_name == github.repository) ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_run' && 
+      github.event.workflow_run.conclusion == 'success' && 
+      github.event.workflow_run.event == 'release' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     permissions:
       contents: read
       id-token: write
@@ -35,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Set up uv
@@ -75,8 +73,8 @@ jobs:
         id: get_version
         run: |
           # Strips 'v' prefix from tag_name (e.g. v0.2.1 -> 0.2.1)
-          # Use head_branch for workflow_run, or ref_name for dispatch
-          VERSION=${{ github.event.workflow_run.head_branch || github.ref_name }}
+          # In workflow_run for a release, head_branch contains the tag name.
+          VERSION=${{ github.event.workflow_run.head_branch }}
           echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
 
       - name: Retrieve release distributions


### PR DESCRIPTION
### Summary
This PR decouples the `docker-publish` and `python-publish` workflows from the main `CI` workflow to improve build speed and security.

### Changes
- **Triggers**: `docker-publish.yml` and `python-publish.yml` are now triggered by the completion of the `CI` workflow (`workflow_run`), ensuring that only code that passes all tests is published.
- **Security**: Added `head_repository` checks to prevent the execution of untrusted code in a trusted context (addressing CodeQL concerns).
- **Optimization**: Added `paths` filters to `ci.yml` to skip unnecessary runs on documentation changes.
- **Validation**:
    - Added a `pypi-build` job to the CI to catch packaging errors early.
    - Updated the Docker smoke test to verify both CLI help and package import.
- **Correct Tagging**: Fixed an issue in `docker-publish` to ensure semantic versioning tags are correctly generated for releases.
- **Repository Targets**: `docker-publish` correctly routes to the organization for releases and to the personal repository for merges to `main`.
