### PR TITLE
fix: storm track explorer projection and filter bar

### DIFF
--- a/docs/_static/explorer.html
+++ b/docs/_static/explorer.html
@@ -459,10 +459,15 @@ function changeSpeed(delta) {
 }
 
 function updateSliderFill() {
-    [elements.strength, elements.duration, elements.displacement].forEach(el => {
+    [elements.duration, elements.displacement].forEach(el => {
         const val = (el.value - el.min) / (el.max - el.min) * 100;
         el.style.background = `linear-gradient(to right, #007bff ${val}%, #ddd ${val}%)`;
     });
+    
+    // Peak Strength fills from right (Minimum Intensity)
+    const sVal = (elements.strength.value - elements.strength.min) / (elements.strength.max - elements.strength.min) * 100;
+    elements.strength.style.background = `linear-gradient(to left, #007bff ${100 - sVal}%, #ddd ${100 - sVal}%)`;
+
     const min = parseInt(elements.timeStart.min);
     const max = parseInt(elements.timeStart.max);
     const v1 = parseInt(elements.timeStart.value);
@@ -541,7 +546,7 @@ function setupControls() {
             } else if (el !== elements.timeStart && el !== elements.timeEnd) {
                 if (isPlaying) pauseAnimation();
             }
-            if (el === elements.strength || el === elements.duration || el === elements.displacement) {
+            if (el === elements.projection || el === elements.strength || el === elements.duration || el === elements.displacement) {
                 updatePlot(true); // force structural rebuild
             } else {
                 updatePlot(false);

--- a/docs/_static/explorer.html
+++ b/docs/_static/explorer.html
@@ -1,802 +1,1314 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Interactive Storm Tracks</title>
     <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
     <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; margin: 0; padding: 10px; color: #333; }
-        .controls { 
-            display: grid; 
-            grid-template-columns: repeat(4, 1fr); 
-            gap: 15px; 
-            background: #f8f9fa; 
-            padding: 15px; 
-            border-radius: 8px; 
-            border: 1px solid #ddd; 
-            margin-bottom: 10px; 
-        }
-        
-        .control-group.playback-group { grid-column: 1 / -1; }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+          sans-serif;
+        margin: 0;
+        padding: 10px;
+        color: #333;
+      }
+      .controls {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 15px;
+        background: #f8f9fa;
+        padding: 15px;
+        border-radius: 8px;
+        border: 1px solid #ddd;
+        margin-bottom: 10px;
+      }
 
-        @media (max-width: 900px) {
-            .controls { grid-template-columns: 1fr 1fr; }
-        }
+      .control-group.playback-group {
+        grid-column: 1 / -1;
+      }
 
-        @media (max-width: 600px) {
-            .controls { gap: 8px; padding: 10px; }
-            body { padding: 5px; }
-            .control-group label { margin-bottom: 2px; font-size: 0.8em; }
-            input[type="range"] { height: 4px; margin: 4px 0; }
-            input[type="range"]::-webkit-slider-thumb { width: 14px; height: 14px; }
-            .range-slider { height: 16px; }
-            .title-bar { margin-bottom: 5px; }
-            .title-bar h2 { font-size: 1.1em; }
-            .btn { padding: 4px 6px; font-size: 0.75em; }
-            .slider-values { font-size: 0.7em; }
-            .color-scale { width: 40px !important; }
-            .color-scale-labels { font-size: 8px !important; }
+      @media (max-width: 900px) {
+        .controls {
+          grid-template-columns: 1fr 1fr;
         }
+      }
 
-        .control-group { display: flex; flex-direction: column; }
-        .control-group label { font-weight: bold; margin-bottom: 5px; font-size: 0.9em; }
-        .slider-values { display: flex; justify-content: space-between; font-size: 0.8em; color: #666; margin-top: 2px; }
-        
-        .plot-container { position: relative; width: 100%; height: 700px; border: 1px solid #eee; border-radius: 8px; display: flex; }
-        #plot-wrapper { flex: 1; position: relative; height: 100%; overflow: hidden; }
-        #plot { width: 100%; height: 100%; }
-        
-        .color-scale { 
-            width: 60px; 
-            height: 100%; 
-            display: flex; 
-            flex-direction: column; 
-            align-items: center; 
-            padding: 40px 0; 
-            font-size: 10px; 
-            color: #666;
-            background: #fff;
-            border-right: 1px solid #eee;
-            border-radius: 8px 0 0 8px;
-            box-sizing: border-box;
+      @media (max-width: 600px) {
+        .controls {
+          gap: 8px;
+          padding: 10px;
         }
-        .color-bar-wrapper { flex: 1; display: flex; flex-direction: row; gap: 4px; }
-        .color-bar { 
-            width: 12px; 
-            height: 100%; 
-            background: linear-gradient(to bottom, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1));
-            border-radius: 6px;
+        body {
+          padding: 5px;
         }
-        .color-scale-labels { height: 100%; display: flex; flex-direction: column; justify-content: space-between; align-items: flex-start; }
-
-        select { width: 100%; cursor: pointer; padding: 4px; border-radius: 4px; border: 1px solid #ccc; background: #fff; height: auto; font-size: 0.9em; }
-        
-        input[type="range"] { width: 100%; cursor: pointer; -webkit-appearance: none; background: #ddd; height: 6px; border-radius: 3px; outline: none; margin: 10px 0; }
-        input[type="range"]::-webkit-slider-thumb { -webkit-appearance: none; width: 16px; height: 16px; background: #007bff; border-radius: 50%; cursor: pointer; border: 1px solid #0056b3; position: relative; z-index: 2; }
-        
-        #time-scrub::-webkit-slider-thumb { width: 16px; height: 26px; background: linear-gradient(to right, transparent 6px, #dc3545 6px, #dc3545 10px, transparent 10px); border-radius: 0; border: none; cursor: ew-resize; z-index: 3; -webkit-appearance: none; transition: opacity 0.2s; }
-        #time-scrub::-moz-range-thumb { width: 16px; height: 26px; background: linear-gradient(to right, transparent 6px, #dc3545 6px, #dc3545 10px, transparent 10px); border-radius: 0; border: none; cursor: ew-resize; z-index: 3; transition: opacity 0.2s; }
-
-        .range-slider.not-animating #time-scrub::-webkit-slider-thumb { opacity: 0; cursor: default; }
-        .range-slider.not-animating #time-scrub::-moz-range-thumb { opacity: 0; cursor: default; }
-
-        .range-slider { position: relative; width: 100%; height: 30px; display: flex; align-items: center; }
-        .range-slider input[type="range"] { position: absolute; left: 0; margin: 0; pointer-events: none; background: none; top: 50%; transform: translateY(-50%); }
-        .range-slider input[type="range"]::-webkit-slider-thumb { pointer-events: auto; }
-        .range-slider input[type="range"]::-moz-range-thumb { pointer-events: auto; }
-        .range-slider .slider-track { 
-            position: absolute; height: 6px; width: 100%; background: #ddd; border-radius: 3px; top: 50%; transform: translateY(-50%); z-index: 0; 
-            --p1: 0; --p2: 1; --ps: 0; --pt: 0;
-            --c1: calc(8px + var(--p1) * (100% - 16px));
-            --c2: calc(8px + var(--p2) * (100% - 16px));
-            --cs: calc(8px + var(--ps) * (100% - 16px));
-            --ct: calc(8px + var(--pt) * (100% - 16px));
-            background: linear-gradient(to right, #ddd 0%, #ddd var(--c1), #99c7ff var(--c1), #99c7ff var(--ct), #007bff var(--ct), #007bff var(--cs), #99c7ff var(--cs), #99c7ff var(--c2), #ddd var(--c2), #ddd 100%);
+        .control-group label {
+          margin-bottom: 2px;
+          font-size: 0.8em;
         }
-        
-        .title-bar { margin-bottom: 10px; border-left: 4px solid #007bff; padding-left: 10px; display: flex; align-items: baseline; justify-content: space-between; padding-right: 15px; }
-        .title-bar h2 { margin: 0; font-size: 1.2em; }
-        .title-bar .version { font-size: 0.85em; color: #666; font-family: monospace; }
-        .loading { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: rgba(255,255,255,0.8); padding: 20px; border-radius: 10px; z-index: 100; font-weight: bold; }
-        .btn { padding: 5px 10px; border: 1px solid #ccc; border-radius: 4px; background: #fff; cursor: pointer; text-align: center; }
-        .btn:hover:not(:disabled) { background: #e9ecef; }
-        .btn:disabled { opacity: 0.5; cursor: not-allowed; }
-        
-        #fps-display { position: absolute; top: 10px; right: 10px; background: rgba(0,0,0,0.5); color: white; padding: 2px 5px; border-radius: 3px; font-size: 10px; z-index: 1000; pointer-events: none; display: none; }
-        #fps-toggle { position: absolute; top: 0; right: 0; width: 100px; height: 100px; z-index: 1001; cursor: default; }
+        input[type="range"] {
+          height: 4px;
+          margin: 4px 0;
+        }
+        input[type="range"]::-webkit-slider-thumb {
+          width: 14px;
+          height: 14px;
+        }
+        .range-slider {
+          height: 16px;
+        }
+        .title-bar {
+          margin-bottom: 5px;
+        }
+        .title-bar h2 {
+          font-size: 1.1em;
+        }
+        .btn {
+          padding: 4px 6px;
+          font-size: 0.75em;
+        }
+        .slider-values {
+          font-size: 0.7em;
+        }
+        .color-scale {
+          width: 40px !important;
+        }
+        .color-scale-labels {
+          font-size: 8px !important;
+        }
+      }
+
+      .control-group {
+        display: flex;
+        flex-direction: column;
+      }
+      .control-group label {
+        font-weight: bold;
+        margin-bottom: 5px;
+        font-size: 0.9em;
+      }
+      .slider-values {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.8em;
+        color: #666;
+        margin-top: 2px;
+      }
+
+      .plot-container {
+        position: relative;
+        width: 100%;
+        height: 700px;
+        border: 1px solid #eee;
+        border-radius: 8px;
+        display: flex;
+      }
+      #plot-wrapper {
+        flex: 1;
+        position: relative;
+        height: 100%;
+        overflow: hidden;
+      }
+      #plot {
+        width: 100%;
+        height: 100%;
+      }
+
+      .color-scale {
+        width: 60px;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 40px 0;
+        font-size: 10px;
+        color: #666;
+        background: #fff;
+        border-right: 1px solid #eee;
+        border-radius: 8px 0 0 8px;
+        box-sizing: border-box;
+      }
+      .color-bar-wrapper {
+        flex: 1;
+        display: flex;
+        flex-direction: row;
+        gap: 4px;
+      }
+      .color-bar {
+        width: 12px;
+        height: 100%;
+        background: linear-gradient(
+          to bottom,
+          rgb(48, 18, 59),
+          rgb(70, 74, 164),
+          rgb(61, 126, 237),
+          rgb(33, 176, 213),
+          rgb(24, 215, 160),
+          rgb(100, 240, 91),
+          rgb(178, 230, 54),
+          rgb(238, 182, 48),
+          rgb(254, 112, 28),
+          rgb(226, 45, 6),
+          rgb(158, 1, 1)
+        );
+        border-radius: 6px;
+      }
+      .color-scale-labels {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: flex-start;
+      }
+
+      select {
+        width: 100%;
+        cursor: pointer;
+        padding: 4px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        background: #fff;
+        height: auto;
+        font-size: 0.9em;
+      }
+
+      input[type="range"] {
+        width: 100%;
+        cursor: pointer;
+        -webkit-appearance: none;
+        background: #ddd;
+        height: 6px;
+        border-radius: 3px;
+        outline: none;
+        margin: 10px 0;
+      }
+      input[type="range"]::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        width: 16px;
+        height: 16px;
+        background: #007bff;
+        border-radius: 50%;
+        cursor: pointer;
+        border: 1px solid #0056b3;
+        position: relative;
+        z-index: 2;
+      }
+
+      #time-scrub::-webkit-slider-thumb {
+        width: 16px;
+        height: 26px;
+        background: linear-gradient(
+          to right,
+          transparent 6px,
+          #dc3545 6px,
+          #dc3545 10px,
+          transparent 10px
+        );
+        border-radius: 0;
+        border: none;
+        cursor: ew-resize;
+        z-index: 3;
+        -webkit-appearance: none;
+        transition: opacity 0.2s;
+      }
+      #time-scrub::-moz-range-thumb {
+        width: 16px;
+        height: 26px;
+        background: linear-gradient(
+          to right,
+          transparent 6px,
+          #dc3545 6px,
+          #dc3545 10px,
+          transparent 10px
+        );
+        border-radius: 0;
+        border: none;
+        cursor: ew-resize;
+        z-index: 3;
+        transition: opacity 0.2s;
+      }
+
+      .range-slider.not-animating #time-scrub::-webkit-slider-thumb {
+        opacity: 0;
+        cursor: default;
+      }
+      .range-slider.not-animating #time-scrub::-moz-range-thumb {
+        opacity: 0;
+        cursor: default;
+      }
+
+      .range-slider {
+        position: relative;
+        width: 100%;
+        height: 30px;
+        display: flex;
+        align-items: center;
+      }
+      .range-slider input[type="range"] {
+        position: absolute;
+        left: 0;
+        margin: 0;
+        pointer-events: none;
+        background: none;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+      .range-slider input[type="range"]::-webkit-slider-thumb {
+        pointer-events: auto;
+      }
+      .range-slider input[type="range"]::-moz-range-thumb {
+        pointer-events: auto;
+      }
+      .range-slider .slider-track {
+        position: absolute;
+        height: 6px;
+        width: 100%;
+        background: #ddd;
+        border-radius: 3px;
+        top: 50%;
+        transform: translateY(-50%);
+        z-index: 0;
+        --p1: 0;
+        --p2: 1;
+        --ps: 0;
+        --pt: 0;
+        --c1: calc(8px + var(--p1) * (100% - 16px));
+        --c2: calc(8px + var(--p2) * (100% - 16px));
+        --cs: calc(8px + var(--ps) * (100% - 16px));
+        --ct: calc(8px + var(--pt) * (100% - 16px));
+        background: linear-gradient(
+          to right,
+          #ddd 0%,
+          #ddd var(--c1),
+          #99c7ff var(--c1),
+          #99c7ff var(--ct),
+          #007bff var(--ct),
+          #007bff var(--cs),
+          #99c7ff var(--cs),
+          #99c7ff var(--c2),
+          #ddd var(--c2),
+          #ddd 100%
+        );
+      }
+
+      .title-bar {
+        margin-bottom: 10px;
+        border-left: 4px solid #007bff;
+        padding-left: 10px;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        padding-right: 15px;
+      }
+      .title-bar h2 {
+        margin: 0;
+        font-size: 1.2em;
+      }
+      .title-bar .version {
+        font-size: 0.85em;
+        color: #666;
+        font-family: monospace;
+      }
+      .loading {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: rgba(255, 255, 255, 0.8);
+        padding: 20px;
+        border-radius: 10px;
+        z-index: 100;
+        font-weight: bold;
+      }
+      .btn {
+        padding: 5px 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #fff;
+        cursor: pointer;
+        text-align: center;
+      }
+      .btn:hover:not(:disabled) {
+        background: #e9ecef;
+      }
+      .btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      #fps-display {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: rgba(0, 0, 0, 0.5);
+        color: white;
+        padding: 2px 5px;
+        border-radius: 3px;
+        font-size: 10px;
+        z-index: 1000;
+        pointer-events: none;
+        display: none;
+      }
+      #fps-toggle {
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 100px;
+        height: 100px;
+        z-index: 1001;
+        cursor: default;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
+    <div id="loading" class="loading">Loading track data...</div>
 
-<div id="loading" class="loading">Loading track data...</div>
+    <div class="title-bar">
+      <h2>Storm Track Explorer</h2>
+      <span class="version">PyStormTracker v0.5.0.dev0</span>
+    </div>
 
-<div class="title-bar">
-    <h2>Storm Track Explorer</h2>
-    <span class="version">PyStormTracker v0.5.0.dev0</span>
-</div>
+    <script src="explorer.tracks.js"></script>
 
-<script src="explorer.tracks.js"></script>
-
-<div class="controls">
-    <div class="control-group">
+    <div class="controls">
+      <div class="control-group">
         <label>Map Projection</label>
         <select id="projection">
-            <option value="orthographic">Globe (3D)</option>
-            <option value="equirectangular">Global (Lat/Lon)</option>
+          <option value="orthographic">Globe (3D)</option>
+          <option value="equirectangular">Global (Lat/Lon)</option>
         </select>
-    </div>
-    <div class="control-group">
+      </div>
+      <div class="control-group">
         <label id="strength-label">Peak Strength</label>
-        <input type="range" id="strength">
+        <input type="range" id="strength" />
         <div class="slider-values">
-            <span id="strength-min-val">...</span>
-            <span id="strength-val">...</span>
-            <span id="strength-max-val">...</span>
+          <span id="strength-min-val">...</span>
+          <span id="strength-val">...</span>
+          <span id="strength-max-val">...</span>
         </div>
-    </div>
-    <div class="control-group">
+      </div>
+      <div class="control-group">
         <label>Min Duration (hours)</label>
-        <input type="range" id="duration" step="6">
+        <input type="range" id="duration" step="6" />
         <div class="slider-values">
-            <span>0h</span>
-            <span id="duration-val">42h</span>
-            <span id="duration-max-val">...</span>
+          <span>0h</span>
+          <span id="duration-val">42h</span>
+          <span id="duration-max-val">...</span>
         </div>
-    </div>
-    <div class="control-group">
+      </div>
+      <div class="control-group">
         <label>Min Displacement (km)</label>
-        <input type="range" id="displacement" step="100">
+        <input type="range" id="displacement" step="100" />
         <div class="slider-values">
-            <span id="displacement-min-val">100km</span>
-            <span id="displacement-val">...</span>
-            <span id="displacement-max-val">...</span>
+          <span id="displacement-min-val">100km</span>
+          <span id="displacement-val">...</span>
+          <span id="displacement-max-val">...</span>
         </div>
-    </div>
-    <div class="control-group playback-group">
+      </div>
+      <div class="control-group playback-group">
         <label>Time Range</label>
         <div class="range-slider">
-            <div class="slider-track" id="time-track"></div>
-            <input type="range" id="time-start" step="21600000">
-            <input type="range" id="time-end" step="21600000">
-            <input type="range" id="time-scrub" step="21600000">
+          <div class="slider-track" id="time-track"></div>
+          <input type="range" id="time-start" step="21600000" />
+          <input type="range" id="time-end" step="21600000" />
+          <input type="range" id="time-scrub" step="21600000" />
         </div>
         <div class="slider-values">
-            <span id="time-start-val">...</span>
-            <span id="status" style="color: #dc3545; font-weight: bold; position: absolute; left: 50%; transform: translateX(-50%); white-space: nowrap;">Initializing...</span>
-            <span id="time-end-val">...</span>
+          <span id="time-start-val">...</span>
+          <span
+            id="status"
+            style="
+              color: #dc3545;
+              font-weight: bold;
+              position: absolute;
+              left: 50%;
+              transform: translateX(-50%);
+              white-space: nowrap;
+            "
+            >Initializing...</span
+          >
+          <span id="time-end-val">...</span>
         </div>
-        <div style="display:flex; gap:10px; margin-top:10px; align-items: center; justify-content: center;">
-            <button id="btn-play-pause" class="btn" style="flex: 2;">Play</button>
-            <div style="flex: 1.5; max-width: 180px; display: flex; align-items: center; justify-content: center; gap: 8px;">
-                <label style="display:flex; align-items:center; gap:2px; font-size:0.85em; cursor:pointer; white-space: nowrap;">
-                    <input type="checkbox" id="chk-loop"> Loop
-                </label>
-                <div style="display:flex; border:1px solid #ccc; border-radius:4px; overflow:hidden; background:#fff; height: 26px; flex: 1; min-width: 90px;">
-                    <button id="btn-speed-down" class="btn" style="border:none; border-radius:0; padding: 0; background:none; flex: 1;">-</button>
-                    <div id="speed-val" style="display:flex; align-items:center; justify-content:center; font-size:0.85em; font-weight:bold; border-left:1px solid #eee; border-right:1px solid #eee; flex: 1.5;">1x</div>
-                    <button id="btn-speed-up" class="btn" style="border:none; border-radius:0; padding: 0; background:none; flex: 1;">+</button>
-                </div>
+        <div
+          style="
+            display: flex;
+            gap: 10px;
+            margin-top: 10px;
+            align-items: center;
+            justify-content: center;
+          "
+        >
+          <button id="btn-play-pause" class="btn" style="flex: 2">Play</button>
+          <div
+            style="
+              flex: 1.5;
+              max-width: 180px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              gap: 8px;
+            "
+          >
+            <label
+              style="
+                display: flex;
+                align-items: center;
+                gap: 2px;
+                font-size: 0.85em;
+                cursor: pointer;
+                white-space: nowrap;
+              "
+            >
+              <input type="checkbox" id="chk-loop" /> Loop
+            </label>
+            <div
+              style="
+                display: flex;
+                border: 1px solid #ccc;
+                border-radius: 4px;
+                overflow: hidden;
+                background: #fff;
+                height: 26px;
+                flex: 1;
+                min-width: 90px;
+              "
+            >
+              <button
+                id="btn-speed-down"
+                class="btn"
+                style="
+                  border: none;
+                  border-radius: 0;
+                  padding: 0;
+                  background: none;
+                  flex: 1;
+                "
+              >
+                -
+              </button>
+              <div
+                id="speed-val"
+                style="
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  font-size: 0.85em;
+                  font-weight: bold;
+                  border-left: 1px solid #eee;
+                  border-right: 1px solid #eee;
+                  flex: 1.5;
+                "
+              >
+                1x
+              </div>
+              <button
+                id="btn-speed-up"
+                class="btn"
+                style="
+                  border: none;
+                  border-radius: 0;
+                  padding: 0;
+                  background: none;
+                  flex: 1;
+                "
+              >
+                +
+              </button>
             </div>
-            <button id="btn-reset" class="btn" style="flex: 2;">Reset</button>
+          </div>
+          <button id="btn-reset" class="btn" style="flex: 2">Reset</button>
         </div>
+      </div>
     </div>
-</div>
 
-<div class="plot-container">
-    <div class="color-scale" id="legend">
-        <div style="font-weight: bold; margin-bottom: 12px; font-size: 11px;" id="legend-unit">hPa</div>
-        <div class="color-bar-wrapper">
-            <div class="color-bar" id="legend-bar"></div>
-            <div class="color-scale-labels" id="legend-labels">
-                <span>0</span>
-                <span>-30</span>
-                <span>-60</span>
-            </div>
+    <div class="plot-container">
+      <div class="color-scale" id="legend">
+        <div
+          style="font-weight: bold; margin-bottom: 12px; font-size: 11px"
+          id="legend-unit"
+        >
+          hPa
         </div>
-    </div>
-    <div id="plot-wrapper">
+        <div class="color-bar-wrapper">
+          <div class="color-bar" id="legend-bar"></div>
+          <div class="color-scale-labels" id="legend-labels">
+            <span>0</span>
+            <span>-30</span>
+            <span>-60</span>
+          </div>
+        </div>
+      </div>
+      <div id="plot-wrapper">
         <div id="plot"></div>
         <div id="fps-display">FPS: --</div>
         <div id="fps-toggle"></div>
+      </div>
     </div>
-</div>
 
-<script>
-// Global Constants
-const TURBO_SCALE = [[0.0, [48, 18, 59]], [0.1, [70, 74, 164]], [0.2, [61, 126, 237]], [0.3, [33, 176, 213]], [0.4, [24, 215, 160]], [0.5, [100, 240, 91]], [0.6, [178, 230, 54]], [0.7, [238, 182, 48]], [0.8, [254, 112, 28]], [0.9, [226, 45, 6]], [1.0, [158, 1, 1]]];
-const BASE_STEPS_PER_SEC = 24; 
-const HOUR_MS = 21600000; 
-const SPEEDS = [0.25, 0.5, 1, 2, 4];
-const TRAIL_DAYS_MS = 15 * 24 * 3600 * 1000;
+    <script>
+      // Global Constants
+      const TURBO_SCALE = [
+        [0.0, [48, 18, 59]],
+        [0.1, [70, 74, 164]],
+        [0.2, [61, 126, 237]],
+        [0.3, [33, 176, 213]],
+        [0.4, [24, 215, 160]],
+        [0.5, [100, 240, 91]],
+        [0.6, [178, 230, 54]],
+        [0.7, [238, 182, 48]],
+        [0.8, [254, 112, 28]],
+        [0.9, [226, 45, 6]],
+        [1.0, [158, 1, 1]],
+      ];
+      const BASE_STEPS_PER_SEC = 24;
+      const HOUR_MS = 21600000;
+      const SPEEDS = [0.25, 0.5, 1, 2, 4];
+      const TRAIL_DAYS_MS = 15 * 24 * 3600 * 1000;
 
-// State Variables
-let allData = null;
-let isPlaying = false;
-let currentAnimTime = null;
-let isUpdating = false;
-let isDraggingMap = false;
-let lastFrameTime = 0;
-let lastProj = null;
-let speedIdx = 2; 
-let tracesInitialized = false;
+      // State Variables
+      let allData = null;
+      let isPlaying = false;
+      let currentAnimTime = null;
+      let isUpdating = false;
+      let isDraggingMap = false;
+      let lastFrameTime = 0;
+      let lastProj = null;
+      let speedIdx = 2;
+      let tracesInitialized = false;
 
-// Benchmark
-let frameCount = 0;
-let lastFpsUpdate = 0;
+      // Benchmark
+      let frameCount = 0;
+      let lastFpsUpdate = 0;
 
-// Buffer & Cache Data
-let masterLats, masterLons, masterTimes, masterStrengths, masterHoverTexts;
-let activeTrackIndices = [];
-let renderCache = { built: false, bins: [] };
+      // Buffer & Cache Data
+      let masterLats,
+        masterLons,
+        masterTimes,
+        masterStrengths,
+        masterHoverTexts;
+      let activeTrackIndices = [];
+      let renderCache = { built: false, bins: [] };
 
-const elements = {
-    projection: document.getElementById('projection'),
-    timeStart: document.getElementById('time-start'),
-    timeEnd: document.getElementById('time-end'),
-    timeTrack: document.getElementById('time-track'),
-    timeStartVal: document.getElementById('time-start-val'),
-    timeEndVal: document.getElementById('time-end-val'),
-    timeScrub: document.getElementById('time-scrub'),
-    btnPlayPause: document.getElementById('btn-play-pause'),
-    btnSpeedDown: document.getElementById('btn-speed-down'),
-    btnSpeedUp: document.getElementById('btn-speed-up'),
-    speedVal: document.getElementById('speed-val'),
-    chkLoop: document.getElementById('chk-loop'),
-    btnReset: document.getElementById('btn-reset'),
-    strength: document.getElementById('strength'),
-    strengthLabel: document.getElementById('strength-label'),
-    strengthVal: document.getElementById('strength-val'),
-    strengthMinVal: document.getElementById('strength-min-val'),
-    strengthMaxVal: document.getElementById('strength-max-val'),
-    duration: document.getElementById('duration'),
-    durationVal: document.getElementById('duration-val'),
-    durationMaxVal: document.getElementById('duration-max-val'),
-    displacement: document.getElementById('displacement'),
-    displacementVal: document.getElementById('displacement-val'),
-    displacementMinVal: document.getElementById('displacement-min-val'),
-    displacementMaxVal: document.getElementById('displacement-max-val'),
-    status: document.getElementById('status'),
-    loading: document.getElementById('loading'),
-    plot: document.getElementById('plot'),
-    fpsDisplay: document.getElementById('fps-display'),
-    fpsToggle: document.getElementById('fps-toggle'),
-    legendUnit: document.getElementById('legend-unit'),
-    legendBar: document.getElementById('legend-bar'),
-    legendLabels: document.getElementById('legend-labels')
-};
+      const elements = {
+        projection: document.getElementById("projection"),
+        timeStart: document.getElementById("time-start"),
+        timeEnd: document.getElementById("time-end"),
+        timeTrack: document.getElementById("time-track"),
+        timeStartVal: document.getElementById("time-start-val"),
+        timeEndVal: document.getElementById("time-end-val"),
+        timeScrub: document.getElementById("time-scrub"),
+        btnPlayPause: document.getElementById("btn-play-pause"),
+        btnSpeedDown: document.getElementById("btn-speed-down"),
+        btnSpeedUp: document.getElementById("btn-speed-up"),
+        speedVal: document.getElementById("speed-val"),
+        chkLoop: document.getElementById("chk-loop"),
+        btnReset: document.getElementById("btn-reset"),
+        strength: document.getElementById("strength"),
+        strengthLabel: document.getElementById("strength-label"),
+        strengthVal: document.getElementById("strength-val"),
+        strengthMinVal: document.getElementById("strength-min-val"),
+        strengthMaxVal: document.getElementById("strength-max-val"),
+        duration: document.getElementById("duration"),
+        durationVal: document.getElementById("duration-val"),
+        durationMaxVal: document.getElementById("duration-max-val"),
+        displacement: document.getElementById("displacement"),
+        displacementVal: document.getElementById("displacement-val"),
+        displacementMinVal: document.getElementById("displacement-min-val"),
+        displacementMaxVal: document.getElementById("displacement-max-val"),
+        status: document.getElementById("status"),
+        loading: document.getElementById("loading"),
+        plot: document.getElementById("plot"),
+        fpsDisplay: document.getElementById("fps-display"),
+        fpsToggle: document.getElementById("fps-toggle"),
+        legendUnit: document.getElementById("legend-unit"),
+        legendBar: document.getElementById("legend-bar"),
+        legendLabels: document.getElementById("legend-labels"),
+      };
 
-function formatTime(ms) {
-    if (!ms || isNaN(ms)) return "N/A";
-    return new Date(ms).toISOString().slice(0, 16).replace('T', ' ');
-}
+      function formatTime(ms) {
+        if (!ms || isNaN(ms)) return "N/A";
+        return new Date(ms).toISOString().slice(0, 16).replace("T", " ");
+      }
 
-function getColor(val, isMSL, cmin, cmax) {
-    let t = Math.min(1, Math.max(0, (val - cmin) / (cmax - cmin)));
-    const tc = isMSL ? (1 - t) : t;
-    for (let i = 0; i < TURBO_SCALE.length - 1; i++) {
-        if (tc >= TURBO_SCALE[i][0] && tc <= TURBO_SCALE[i+1][0]) {
-            const ratio = (tc - TURBO_SCALE[i][0]) / (TURBO_SCALE[i+1][0] - TURBO_SCALE[i][0]);
-            const r = Math.round(TURBO_SCALE[i][1][0] + (TURBO_SCALE[i+1][1][0] - TURBO_SCALE[i][1][0]) * ratio);
-            const g = Math.round(TURBO_SCALE[i][1][1] + (TURBO_SCALE[i+1][1][1] - TURBO_SCALE[i][1][1]) * ratio);
-            const b = Math.round(TURBO_SCALE[i][1][2] + (TURBO_SCALE[i+1][1][2] - TURBO_SCALE[i][1][2]) * ratio);
+      function getColor(val, isMSL, cmin, cmax) {
+        let t = Math.min(1, Math.max(0, (val - cmin) / (cmax - cmin)));
+        const tc = isMSL ? 1 - t : t;
+        for (let i = 0; i < TURBO_SCALE.length - 1; i++) {
+          if (tc >= TURBO_SCALE[i][0] && tc <= TURBO_SCALE[i + 1][0]) {
+            const ratio =
+              (tc - TURBO_SCALE[i][0]) /
+              (TURBO_SCALE[i + 1][0] - TURBO_SCALE[i][0]);
+            const r = Math.round(
+              TURBO_SCALE[i][1][0] +
+                (TURBO_SCALE[i + 1][1][0] - TURBO_SCALE[i][1][0]) * ratio,
+            );
+            const g = Math.round(
+              TURBO_SCALE[i][1][1] +
+                (TURBO_SCALE[i + 1][1][1] - TURBO_SCALE[i][1][1]) * ratio,
+            );
+            const b = Math.round(
+              TURBO_SCALE[i][1][2] +
+                (TURBO_SCALE[i + 1][1][2] - TURBO_SCALE[i][1][2]) * ratio,
+            );
             return `rgb(${r}, ${g}, ${b})`;
+          }
         }
-    }
-    return `rgb(0,0,0)`;
-}
+        return `rgb(0,0,0)`;
+      }
 
-async function init() {
-    if (window.TRACKS_DATA) {
-        allData = window.TRACKS_DATA;
-        const meta = allData.metadata;
-        const isMSL = meta.track_type === 'msl';
-        const unit = isMSL ? "hPa" : "10⁻⁵ s⁻¹";
-        
-        const ptCount = allData.points.lat.length;
-        masterLats = new Float32Array(allData.points.lat);
-        masterLons = new Float32Array(allData.points.lon);
-        masterTimes = new Float64Array(allData.points.time);
-        masterStrengths = new Float32Array(allData.points.strength);
-        masterHoverTexts = new Array(ptCount);
-        
-        // 1. Pre-calculate track static texts ONCE to save massive CPU/GC overhead during animation
-        allData.tracks.forEach(t => {
+      async function init() {
+        if (window.TRACKS_DATA) {
+          allData = window.TRACKS_DATA;
+          const meta = allData.metadata;
+          const isMSL = meta.track_type === "msl";
+          const unit = isMSL ? "hPa" : "10⁻⁵ s⁻¹";
+
+          const ptCount = allData.points.lat.length;
+          masterLats = new Float32Array(allData.points.lat);
+          masterLons = new Float32Array(allData.points.lon);
+          masterTimes = new Float64Array(allData.points.time);
+          masterStrengths = new Float32Array(allData.points.strength);
+          masterHoverTexts = new Array(ptCount);
+
+          // 1. Pre-calculate track static texts ONCE to save massive CPU/GC overhead during animation
+          allData.tracks.forEach((t) => {
             const startTimeStr = formatTime(masterTimes[t.start]);
             const endTimeStr = formatTime(masterTimes[t.end]);
             const peakText = `Track ID: ${t.track_id}<br>Peak: ${t.strength.toFixed(1)} ${unit}`;
             const durText = `<br>Start: ${startTimeStr}<br>End: ${endTimeStr}<br>Dur: ${t.duration}h`;
-            
-            for(let p = t.start; p <= t.end; p++) {
-                const ptTimeStr = formatTime(masterTimes[p]);
-                masterHoverTexts[p] = `${peakText}<br>Curr: ${masterStrengths[p].toFixed(1)} ${unit}<br>Time: ${ptTimeStr}${durText}`;
+
+            for (let p = t.start; p <= t.end; p++) {
+              const ptTimeStr = formatTime(masterTimes[p]);
+              masterHoverTexts[p] =
+                `${peakText}<br>Curr: ${masterStrengths[p].toFixed(1)} ${unit}<br>Time: ${ptTimeStr}${durText}`;
             }
-        });
+          });
 
-        setupControls();
-        updateLegend();
-        elements.loading.style.display = 'none';
-        document.querySelector('.range-slider').classList.add('not-animating');
-        
-        elements.btnPlayPause.addEventListener('click', () => isPlaying ? pauseAnimation() : playAnimation());
-        elements.btnSpeedDown.addEventListener('click', () => changeSpeed(-1));
-        elements.btnSpeedUp.addEventListener('click', () => changeSpeed(1));
-        elements.btnReset.addEventListener('click', resetAnimation);
-        window.addEventListener('resize', () => { updatePlot(true); updateLegend(); });
-        
-        elements.plot.addEventListener('mousedown', () => { isDraggingMap = true; });
-        elements.plot.addEventListener('touchstart', () => { isDraggingMap = true; }, {passive: true});
-        window.addEventListener('mouseup', () => { isDraggingMap = false; });
-        window.addEventListener('touchend', () => { isDraggingMap = false; }, {passive: true});
+          setupControls();
+          updateLegend();
+          elements.loading.style.display = "none";
+          document
+            .querySelector(".range-slider")
+            .classList.add("not-animating");
 
-        const toggleFps = () => {
+          elements.btnPlayPause.addEventListener("click", () =>
+            isPlaying ? pauseAnimation() : playAnimation(),
+          );
+          elements.btnSpeedDown.addEventListener("click", () =>
+            changeSpeed(-1),
+          );
+          elements.btnSpeedUp.addEventListener("click", () => changeSpeed(1));
+          elements.btnReset.addEventListener("click", resetAnimation);
+          window.addEventListener("resize", () => {
+            updatePlot(true);
+            updateLegend();
+          });
+
+          elements.plot.addEventListener("mousedown", () => {
+            isDraggingMap = true;
+          });
+          elements.plot.addEventListener(
+            "touchstart",
+            () => {
+              isDraggingMap = true;
+            },
+            { passive: true },
+          );
+          window.addEventListener("mouseup", () => {
+            isDraggingMap = false;
+          });
+          window.addEventListener(
+            "touchend",
+            () => {
+              isDraggingMap = false;
+            },
+            { passive: true },
+          );
+
+          const toggleFps = () => {
             const disp = elements.fpsDisplay.style.display;
-            elements.fpsDisplay.style.display = (disp === 'none' || disp === '') ? 'block' : 'none';
-        };
-        elements.fpsToggle.addEventListener('dblclick', toggleFps);
-        
-        let lastTap = 0;
-        elements.fpsToggle.addEventListener('touchstart', (e) => {
-            const now = performance.now();
-            if (now - lastTap < 300) {
+            elements.fpsDisplay.style.display =
+              disp === "none" || disp === "" ? "block" : "none";
+          };
+          elements.fpsToggle.addEventListener("dblclick", toggleFps);
+
+          let lastTap = 0;
+          elements.fpsToggle.addEventListener(
+            "touchstart",
+            (e) => {
+              const now = performance.now();
+              if (now - lastTap < 300) {
                 toggleFps();
                 e.preventDefault();
-            }
-            lastTap = now;
-        }, {passive: false});
+              }
+              lastTap = now;
+            },
+            { passive: false },
+          );
 
-        elements.timeScrub.addEventListener('input', () => {
+          elements.timeScrub.addEventListener("input", () => {
             if (isPlaying) pauseAnimation();
-            document.querySelector('.range-slider').classList.remove('not-animating');
+            document
+              .querySelector(".range-slider")
+              .classList.remove("not-animating");
             currentAnimTime = parseInt(elements.timeScrub.value);
             updateSliderFill();
             updatePlot(); // time scrub is not a structural change
-        });
+          });
 
-        updatePlot(true);
-    } else {
-        elements.status.innerHTML = `<b style='color:red'>Error:</b> Data script not found. If using split mode, ensure the .tracks.js file is present and loaded correctly.`;
-        elements.loading.innerHTML = `<span style='color:red'>Data failed to load.</span>`;
-    }
-}
+          updatePlot(true);
+        } else {
+          elements.status.innerHTML = `<b style='color:red'>Error:</b> Data script not found. If using split mode, ensure the .tracks.js file is present and loaded correctly.`;
+          elements.loading.innerHTML = `<span style='color:red'>Data failed to load.</span>`;
+        }
+      }
 
-function updateFilterCache() {
-    const meta = allData.metadata;
-    const isMSL = meta.track_type === 'msl';
-    const cmin = meta.min_strength;
-    const cmax = meta.max_strength;
-    
-    const strengthThresh = parseFloat(elements.strength.value);
-    const minDur = parseFloat(elements.duration.value);
-    const minDist = parseFloat(elements.displacement.value);
-    
-    activeTrackIndices = [];
-    
-    const bins = Array(11).fill(0).map(() => ({
-        lats: [], lons: [], times: [], texts: [], colors: []
-    }));
+      function updateFilterCache() {
+        const meta = allData.metadata;
+        const isMSL = meta.track_type === "msl";
+        const cmin = meta.min_strength;
+        const cmax = meta.max_strength;
 
-    for (let i = 0; i < allData.tracks.length; i++) {
-        const t = allData.tracks[i];
-        const sMatch = isMSL ? t.strength <= strengthThresh : t.strength >= strengthThresh;
-        if (sMatch && t.duration >= minDur && t.displacement >= minDist) {
+        const strengthThresh = parseFloat(elements.strength.value);
+        const minDur = parseFloat(elements.duration.value);
+        const minDist = parseFloat(elements.displacement.value);
+
+        activeTrackIndices = [];
+
+        const bins = Array(11)
+          .fill(0)
+          .map(() => ({
+            lats: [],
+            lons: [],
+            times: [],
+            texts: [],
+            colors: [],
+          }));
+
+        for (let i = 0; i < allData.tracks.length; i++) {
+          const t = allData.tracks[i];
+          const sMatch = isMSL
+            ? t.strength <= strengthThresh
+            : t.strength >= strengthThresh;
+          if (sMatch && t.duration >= minDur && t.displacement >= minDist) {
             activeTrackIndices.push(i);
-            
+
             let currentBin = -1;
             for (let p = t.start; p <= t.end; p++) {
-                let v = masterStrengths[p];
-                let t_val = Math.min(1, Math.max(0, (v - cmin) / (cmax - cmin)));
-                const tc = isMSL ? (1 - t_val) : t_val;
-                const newBin = Math.min(Math.floor(tc * 10), 10);
-                const ptColor = `rgb(${TURBO_SCALE[newBin][1].join(',')})`;
-                const hText = masterHoverTexts[p];
-                
-                if (currentBin !== -1 && currentBin !== newBin) {
-                    // Bin changed. Close old, start new.
-                    bins[currentBin].lats.push(masterLats[p], NaN);
-                    bins[currentBin].lons.push(masterLons[p], NaN);
-                    bins[currentBin].times.push(masterTimes[p], masterTimes[p]);
-                    bins[currentBin].texts.push(hText, "");
-                    bins[currentBin].colors.push(ptColor, 'rgba(0,0,0,0)');
-                    
-                    bins[newBin].lats.push(masterLats[p]);
-                    bins[newBin].lons.push(masterLons[p]);
-                    bins[newBin].times.push(masterTimes[p]);
-                    bins[newBin].texts.push(hText);
-                    bins[newBin].colors.push(ptColor);
-                } else {
-                    bins[newBin].lats.push(masterLats[p]);
-                    bins[newBin].lons.push(masterLons[p]);
-                    bins[newBin].times.push(masterTimes[p]);
-                    bins[newBin].texts.push(hText);
-                    bins[newBin].colors.push(ptColor);
-                }
-                currentBin = newBin;
+              let v = masterStrengths[p];
+              let t_val = Math.min(1, Math.max(0, (v - cmin) / (cmax - cmin)));
+              const tc = isMSL ? 1 - t_val : t_val;
+              const newBin = Math.min(Math.floor(tc * 10), 10);
+              const ptColor = `rgb(${TURBO_SCALE[newBin][1].join(",")})`;
+              const hText = masterHoverTexts[p];
+
+              if (currentBin !== -1 && currentBin !== newBin) {
+                // Bin changed. Close old, start new.
+                bins[currentBin].lats.push(masterLats[p], NaN);
+                bins[currentBin].lons.push(masterLons[p], NaN);
+                bins[currentBin].times.push(masterTimes[p], masterTimes[p]);
+                bins[currentBin].texts.push(hText, "");
+                bins[currentBin].colors.push(ptColor, "rgba(0,0,0,0)");
+
+                bins[newBin].lats.push(masterLats[p]);
+                bins[newBin].lons.push(masterLons[p]);
+                bins[newBin].times.push(masterTimes[p]);
+                bins[newBin].texts.push(hText);
+                bins[newBin].colors.push(ptColor);
+              } else {
+                bins[newBin].lats.push(masterLats[p]);
+                bins[newBin].lons.push(masterLons[p]);
+                bins[newBin].times.push(masterTimes[p]);
+                bins[newBin].texts.push(hText);
+                bins[newBin].colors.push(ptColor);
+              }
+              currentBin = newBin;
             }
             if (currentBin !== -1) {
-                bins[currentBin].lats.push(NaN);
-                bins[currentBin].lons.push(NaN);
-                bins[currentBin].times.push(masterTimes[t.end]);
-                bins[currentBin].texts.push("");
-                bins[currentBin].colors.push('rgba(0,0,0,0)');
+              bins[currentBin].lats.push(NaN);
+              bins[currentBin].lons.push(NaN);
+              bins[currentBin].times.push(masterTimes[t.end]);
+              bins[currentBin].texts.push("");
+              bins[currentBin].colors.push("rgba(0,0,0,0)");
             }
+          }
         }
-    }
-    
-    // Compile to TypedArrays for ultra-fast masking during animation
-    bins.forEach(b => {
-        b.f32Lats = new Float32Array(b.lats);
-        b.f32Lons = new Float32Array(b.lons);
-        b.f64Times = new Float64Array(b.times);
-        b.workingLats = new Float32Array(b.lats.length);
-        b.workingLons = new Float32Array(b.lons.length);
-    });
-    
-    renderCache.bins = bins;
-    renderCache.built = true;
-}
 
-function updateLegend() {
-    const meta = allData.metadata;
-    const isMSL = meta.track_type === 'msl';
-    elements.legendUnit.innerText = isMSL ? "hPa" : "10⁻⁵ s⁻¹";
-    
-    const cmin = meta.min_strength;
-    const cmax = meta.max_strength;
-    
-    if (isMSL) {
-        elements.legendBar.style.background = "linear-gradient(to bottom, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1))";
-        elements.legendLabels.innerHTML = `<span>${cmax.toFixed(0)}</span><span>${((cmin+cmax)/2).toFixed(0)}</span><span>${cmin.toFixed(0)}</span>`;
-    } else {
-        elements.legendBar.style.background = "linear-gradient(to top, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1))";
-        elements.legendLabels.innerHTML = `<span>${cmax.toFixed(1)}</span><span>${((cmin+cmax)/2).toFixed(1)}</span><span>${cmin.toFixed(1)}</span>`;
-    }
-}
+        // Compile to TypedArrays for ultra-fast masking during animation
+        bins.forEach((b) => {
+          b.f32Lats = new Float32Array(b.lats);
+          b.f32Lons = new Float32Array(b.lons);
+          b.f64Times = new Float64Array(b.times);
+          b.workingLats = new Float32Array(b.lats.length);
+          b.workingLons = new Float32Array(b.lons.length);
+        });
 
-function changeSpeed(delta) {
-    speedIdx = Math.max(0, Math.min(SPEEDS.length - 1, speedIdx + delta));
-    elements.speedVal.innerText = SPEEDS[speedIdx] + 'x';
-}
+        renderCache.bins = bins;
+        renderCache.built = true;
+      }
 
-function updateSliderFill() {
-    [elements.duration, elements.displacement].forEach(el => {
-        const val = (el.value - el.min) / (el.max - el.min) * 100;
-        el.style.background = `linear-gradient(to right, #007bff ${val}%, #ddd ${val}%)`;
-    });
-    
-    // Peak Strength fills from right (Minimum Intensity)
-    const sVal = (elements.strength.value - elements.strength.min) / (elements.strength.max - elements.strength.min) * 100;
-    elements.strength.style.background = `linear-gradient(to left, #007bff ${100 - sVal}%, #ddd ${100 - sVal}%)`;
+      function updateLegend() {
+        const meta = allData.metadata;
+        const isMSL = meta.track_type === "msl";
+        elements.legendUnit.innerText = isMSL ? "hPa" : "10⁻⁵ s⁻¹";
 
-    const min = parseInt(elements.timeStart.min);
-    const max = parseInt(elements.timeStart.max);
-    const v1 = parseInt(elements.timeStart.value);
-    const v2 = parseInt(elements.timeEnd.value);
-    const vs = parseInt(elements.timeScrub.value);
-    
-    // Trail calculation for timeline background
-    const tailTime = Math.max(v1, vs - TRAIL_DAYS_MS);
-    
-    const p1 = (v1 - min) / (max - min);
-    const p2 = (v2 - min) / (max - min);
-    const ps = (vs - min) / (max - min);
-    const pt = (tailTime - min) / (max - min);
-    
-    elements.timeTrack.style.setProperty('--p1', p1);
-    elements.timeTrack.style.setProperty('--p2', p2);
-    elements.timeTrack.style.setProperty('--ps', ps);
-    elements.timeTrack.style.setProperty('--pt', pt);
-}
+        const cmin = meta.min_strength;
+        const cmax = meta.max_strength;
 
-function setupControls() {
-    const meta = allData.metadata;
-    const isMSL = meta.track_type === 'msl';
-    
-    [elements.timeStart, elements.timeEnd, elements.timeScrub].forEach(el => {
-        el.min = meta.min_time;
-        el.max = meta.max_time;
-    });
-    
-    elements.timeStart.value = meta.min_time;
-    elements.timeEnd.value = meta.max_time;
-    elements.timeScrub.value = meta.min_time;
-
-    elements.timeStart.addEventListener('input', () => {
-        if (parseInt(elements.timeStart.value) >= parseInt(elements.timeEnd.value)) {
-            elements.timeStart.value = parseInt(elements.timeEnd.value) - HOUR_MS;
+        if (isMSL) {
+          elements.legendBar.style.background =
+            "linear-gradient(to bottom, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1))";
+          elements.legendLabels.innerHTML = `<span>${cmax.toFixed(0)}</span><span>${((cmin + cmax) / 2).toFixed(0)}</span><span>${cmin.toFixed(0)}</span>`;
+        } else {
+          elements.legendBar.style.background =
+            "linear-gradient(to top, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1))";
+          elements.legendLabels.innerHTML = `<span>${cmax.toFixed(1)}</span><span>${((cmin + cmax) / 2).toFixed(1)}</span><span>${cmin.toFixed(1)}</span>`;
         }
-        if (currentAnimTime !== null && parseInt(elements.timeScrub.value) < parseInt(elements.timeStart.value)) {
+      }
+
+      function changeSpeed(delta) {
+        speedIdx = Math.max(0, Math.min(SPEEDS.length - 1, speedIdx + delta));
+        elements.speedVal.innerText = SPEEDS[speedIdx] + "x";
+      }
+
+      function updateSliderFill() {
+        [elements.duration, elements.displacement].forEach((el) => {
+          const val = ((el.value - el.min) / (el.max - el.min)) * 100;
+          el.style.background = `linear-gradient(to right, #007bff ${val}%, #ddd ${val}%)`;
+        });
+
+        // Peak Strength fills from right (Minimum Intensity)
+        const sVal =
+          ((elements.strength.value - elements.strength.min) /
+            (elements.strength.max - elements.strength.min)) *
+          100;
+        elements.strength.style.background = `linear-gradient(to left, #007bff ${100 - sVal}%, #ddd ${100 - sVal}%)`;
+
+        const min = parseInt(elements.timeStart.min);
+        const max = parseInt(elements.timeStart.max);
+        const v1 = parseInt(elements.timeStart.value);
+        const v2 = parseInt(elements.timeEnd.value);
+        const vs = parseInt(elements.timeScrub.value);
+
+        // Trail calculation for timeline background
+        const tailTime = Math.max(v1, vs - TRAIL_DAYS_MS);
+
+        const p1 = (v1 - min) / (max - min);
+        const p2 = (v2 - min) / (max - min);
+        const ps = (vs - min) / (max - min);
+        const pt = (tailTime - min) / (max - min);
+
+        elements.timeTrack.style.setProperty("--p1", p1);
+        elements.timeTrack.style.setProperty("--p2", p2);
+        elements.timeTrack.style.setProperty("--ps", ps);
+        elements.timeTrack.style.setProperty("--pt", pt);
+      }
+
+      function setupControls() {
+        const meta = allData.metadata;
+        const isMSL = meta.track_type === "msl";
+
+        [elements.timeStart, elements.timeEnd, elements.timeScrub].forEach(
+          (el) => {
+            el.min = meta.min_time;
+            el.max = meta.max_time;
+          },
+        );
+
+        elements.timeStart.value = meta.min_time;
+        elements.timeEnd.value = meta.max_time;
+        elements.timeScrub.value = meta.min_time;
+
+        elements.timeStart.addEventListener("input", () => {
+          if (
+            parseInt(elements.timeStart.value) >=
+            parseInt(elements.timeEnd.value)
+          ) {
+            elements.timeStart.value =
+              parseInt(elements.timeEnd.value) - HOUR_MS;
+          }
+          if (
+            currentAnimTime !== null &&
+            parseInt(elements.timeScrub.value) <
+              parseInt(elements.timeStart.value)
+          ) {
             elements.timeScrub.value = elements.timeStart.value;
             currentAnimTime = parseInt(elements.timeScrub.value);
-        }
-    });
-    elements.timeEnd.addEventListener('input', () => {
-        if (parseInt(elements.timeEnd.value) <= parseInt(elements.timeStart.value)) {
-            elements.timeEnd.value = parseInt(elements.timeStart.value) + HOUR_MS;
-        }
-        if (currentAnimTime !== null && parseInt(elements.timeScrub.value) > parseInt(elements.timeEnd.value)) {
+          }
+        });
+        elements.timeEnd.addEventListener("input", () => {
+          if (
+            parseInt(elements.timeEnd.value) <=
+            parseInt(elements.timeStart.value)
+          ) {
+            elements.timeEnd.value =
+              parseInt(elements.timeStart.value) + HOUR_MS;
+          }
+          if (
+            currentAnimTime !== null &&
+            parseInt(elements.timeScrub.value) >
+              parseInt(elements.timeEnd.value)
+          ) {
             elements.timeScrub.value = elements.timeEnd.value;
             currentAnimTime = parseInt(elements.timeScrub.value);
-        }
-    });
-    
-    elements.strengthLabel.innerText = isMSL ? "Peak MSL (hPa)" : "Peak VO (10⁻⁵ s⁻¹)";
-    elements.strength.min = Math.floor(meta.min_strength);
-    elements.strength.max = Math.ceil(meta.max_strength);
-    elements.strength.step = isMSL ? 1 : 0.1;
-    elements.strength.value = isMSL ? Math.max(elements.strength.min, Math.min(elements.strength.max, -15)) : Math.floor(meta.min_strength);
-    elements.strengthMinVal.innerText = elements.strength.min;
-    elements.strengthMaxVal.innerText = elements.strength.max;
-    
-    elements.duration.min = 0;
-    elements.duration.max = Math.ceil(meta.max_duration);
-    elements.duration.value = 48;
-    elements.durationMaxVal.innerText = elements.duration.max + "h";
-    
-    const roundedMaxDisp = Math.ceil(meta.max_displacement / 100) * 100;
-    elements.displacement.min = 100;
-    elements.displacement.max = roundedMaxDisp;
-    elements.displacement.value = Math.min(1000, roundedMaxDisp);
-    elements.displacementMaxVal.innerText = roundedMaxDisp + "km";
-    
-    [elements.projection, elements.timeStart, elements.timeEnd, elements.strength, elements.duration, elements.displacement].forEach(el => {
-        el.addEventListener('input', () => {
-            if (isPlaying && (el === elements.timeStart || el === elements.timeEnd)) {
-                pauseAnimation();
+          }
+        });
+
+        elements.strengthLabel.innerText = isMSL
+          ? "Peak MSL (hPa)"
+          : "Peak VO (10⁻⁵ s⁻¹)";
+        elements.strength.min = Math.floor(meta.min_strength);
+        elements.strength.max = Math.ceil(meta.max_strength);
+        elements.strength.step = isMSL ? 1 : 0.1;
+        elements.strength.value = isMSL
+          ? Math.max(
+              elements.strength.min,
+              Math.min(elements.strength.max, -15),
+            )
+          : Math.floor(meta.min_strength);
+        elements.strengthMinVal.innerText = elements.strength.min;
+        elements.strengthMaxVal.innerText = elements.strength.max;
+
+        elements.duration.min = 0;
+        elements.duration.max = Math.ceil(meta.max_duration);
+        elements.duration.value = 48;
+        elements.durationMaxVal.innerText = elements.duration.max + "h";
+
+        const roundedMaxDisp = Math.ceil(meta.max_displacement / 100) * 100;
+        elements.displacement.min = 100;
+        elements.displacement.max = roundedMaxDisp;
+        elements.displacement.value = Math.min(1000, roundedMaxDisp);
+        elements.displacementMaxVal.innerText = roundedMaxDisp + "km";
+
+        [
+          elements.projection,
+          elements.timeStart,
+          elements.timeEnd,
+          elements.strength,
+          elements.duration,
+          elements.displacement,
+        ].forEach((el) => {
+          el.addEventListener("input", () => {
+            if (
+              isPlaying &&
+              (el === elements.timeStart || el === elements.timeEnd)
+            ) {
+              pauseAnimation();
             } else if (el !== elements.timeStart && el !== elements.timeEnd) {
-                if (isPlaying) pauseAnimation();
+              if (isPlaying) pauseAnimation();
             }
-            if (el === elements.projection || el === elements.strength || el === elements.duration || el === elements.displacement) {
-                updatePlot(true); // force structural rebuild
+            if (
+              el === elements.projection ||
+              el === elements.strength ||
+              el === elements.duration ||
+              el === elements.displacement
+            ) {
+              updatePlot(true); // force structural rebuild
             } else {
-                updatePlot(false);
+              updatePlot(false);
             }
             updateSliderFill();
+          });
         });
-    });
-    updateSliderFill();
-}
+        updateSliderFill();
+      }
 
-function animate(timestamp) {
-    if (!isPlaying) return;
-    
-    if (!lastFrameTime) lastFrameTime = timestamp;
-    const dt = timestamp - lastFrameTime;
-    
-    const targetStepsPerSec = BASE_STEPS_PER_SEC * SPEEDS[speedIdx];
-    const msPerStep = 1000 / targetStepsPerSec;
-    
-    if (dt >= msPerStep) {
-        const tStart = parseInt(elements.timeStart.value);
-        const tEnd = parseInt(elements.timeEnd.value);
-        
-        if (currentAnimTime === null) currentAnimTime = tStart;
+      function animate(timestamp) {
+        if (!isPlaying) return;
 
-        if (!isDraggingMap) {
+        if (!lastFrameTime) lastFrameTime = timestamp;
+        const dt = timestamp - lastFrameTime;
+
+        const targetStepsPerSec = BASE_STEPS_PER_SEC * SPEEDS[speedIdx];
+        const msPerStep = 1000 / targetStepsPerSec;
+
+        if (dt >= msPerStep) {
+          const tStart = parseInt(elements.timeStart.value);
+          const tEnd = parseInt(elements.timeEnd.value);
+
+          if (currentAnimTime === null) currentAnimTime = tStart;
+
+          if (!isDraggingMap) {
             const stepsToAdvance = Math.floor(dt / msPerStep);
             let nextTime = currentAnimTime;
-            
+
             for (let i = 0; i < stepsToAdvance; i++) {
-                if (nextTime >= tEnd) {
-                    if (elements.chkLoop.checked) {
-                        nextTime = tStart;
-                    } else {
-                        nextTime = tEnd;
-                        pauseAnimation();
-                        break;
-                    }
+              if (nextTime >= tEnd) {
+                if (elements.chkLoop.checked) {
+                  nextTime = tStart;
                 } else {
-                    nextTime = Math.min(tEnd, nextTime + HOUR_MS);
+                  nextTime = tEnd;
+                  pauseAnimation();
+                  break;
                 }
+              } else {
+                nextTime = Math.min(tEnd, nextTime + HOUR_MS);
+              }
             }
-            
+
             currentAnimTime = nextTime;
             elements.timeScrub.value = currentAnimTime;
             updateSliderFill();
             updatePlot();
+          }
+
+          lastFrameTime = timestamp - (dt % msPerStep);
         }
-        
-        lastFrameTime = timestamp - (dt % msPerStep);
-    }
-    
-    if (isPlaying) {
+
+        if (isPlaying) {
+          requestAnimationFrame(animate);
+        }
+      }
+
+      function playAnimation() {
+        if (isPlaying) return;
+        isPlaying = true;
+        elements.btnPlayPause.innerText = "Pause";
+        document
+          .querySelector(".range-slider")
+          .classList.remove("not-animating");
+
+        const tStart = parseInt(elements.timeStart.value);
+        const tEnd = parseInt(elements.timeEnd.value);
+        if (currentAnimTime === null || currentAnimTime >= tEnd)
+          currentAnimTime = tStart;
+
+        lastFrameTime = 0;
         requestAnimationFrame(animate);
-    }
-}
+      }
 
-function playAnimation() {
-    if (isPlaying) return;
-    isPlaying = true;
-    elements.btnPlayPause.innerText = 'Pause';
-    document.querySelector('.range-slider').classList.remove('not-animating');
-    
-    const tStart = parseInt(elements.timeStart.value);
-    const tEnd = parseInt(elements.timeEnd.value);
-    if (currentAnimTime === null || currentAnimTime >= tEnd) currentAnimTime = tStart;
-    
-    lastFrameTime = 0;
-    requestAnimationFrame(animate);
-}
+      function pauseAnimation() {
+        isPlaying = false;
+        elements.btnPlayPause.innerText = "Play";
+        updatePlot();
+      }
 
-function pauseAnimation() {
-    isPlaying = false;
-    elements.btnPlayPause.innerText = 'Play';
-    updatePlot();
-}
+      function resetAnimation() {
+        pauseAnimation();
+        currentAnimTime = null;
+        speedIdx = 2;
+        elements.speedVal.innerText = "1x";
+        elements.timeScrub.value = elements.timeStart.value;
+        document.querySelector(".range-slider").classList.add("not-animating");
+        updateSliderFill();
+        updatePlot(true);
+      }
 
-function resetAnimation() { 
-    pauseAnimation(); 
-    currentAnimTime = null; 
-    speedIdx = 2; 
-    elements.speedVal.innerText = '1x';
-    elements.timeScrub.value = elements.timeStart.value;
-    document.querySelector('.range-slider').classList.add('not-animating');
-    updateSliderFill();
-    updatePlot(true); 
-}
+      function updatePlot(forceStructural = false) {
+        if (isUpdating && !forceStructural) return;
+        isUpdating = true;
 
-function updatePlot(forceStructural = false) {
-    if (isUpdating && !forceStructural) return;
-    isUpdating = true;
-    
-    frameCount++;
-    const now = performance.now();
-    if (now - lastFpsUpdate >= 1000) {
-        elements.fpsDisplay.innerText = "FPS: " + frameCount;
-        frameCount = 0;
-        lastFpsUpdate = now;
-    }
+        frameCount++;
+        const now = performance.now();
+        if (now - lastFpsUpdate >= 1000) {
+          elements.fpsDisplay.innerText = "FPS: " + frameCount;
+          frameCount = 0;
+          lastFpsUpdate = now;
+        }
 
-    if (forceStructural || !renderCache.built) {
-        updateFilterCache();
-    }
+        if (forceStructural || !renderCache.built) {
+          updateFilterCache();
+        }
 
-    const meta = allData.metadata;
-    const isMSL = meta.track_type === 'msl';
-    const cmin = meta.min_strength;
-    const cmax = meta.max_strength;
-    
-    const tStart = parseInt(elements.timeStart.value);
-    const tEnd = parseInt(elements.timeEnd.value);
-    const proj = elements.projection.value;
+        const meta = allData.metadata;
+        const isMSL = meta.track_type === "msl";
+        const cmin = meta.min_strength;
+        const cmax = meta.max_strength;
 
-    const isProjChanged = proj !== lastProj || forceStructural;
-    lastProj = proj;
+        const tStart = parseInt(elements.timeStart.value);
+        const tEnd = parseInt(elements.timeEnd.value);
+        const proj = elements.projection.value;
 
-    const winW = window.innerWidth;
-    const isMobile = winW < 600;
-    const isTiny = winW < 400;
-    const plotHeight = proj === 'equirectangular' 
-        ? (isTiny ? 200 : (isMobile ? 250 : 450)) 
-        : (isTiny ? 320 : (isMobile ? 400 : 700));
-    elements.plot.style.height = plotHeight + 'px';
-    document.querySelector('.plot-container').style.height = plotHeight + 'px';
+        const isProjChanged = proj !== lastProj || forceStructural;
+        lastProj = proj;
 
-    elements.timeStartVal.innerText = formatTime(tStart);
-    elements.timeEndVal.innerText = formatTime(tEnd);
+        const winW = window.innerWidth;
+        const isMobile = winW < 600;
+        const isTiny = winW < 400;
+        const plotHeight =
+          proj === "equirectangular"
+            ? isTiny
+              ? 200
+              : isMobile
+                ? 250
+                : 450
+            : isTiny
+              ? 320
+              : isMobile
+                ? 400
+                : 700;
+        elements.plot.style.height = plotHeight + "px";
+        document.querySelector(".plot-container").style.height =
+          plotHeight + "px";
 
-    const restyleLat = [];
-    const restyleLon = [];
-    const limitTime = currentAnimTime !== null ? currentAnimTime : tEnd;
-    const tailTime = currentAnimTime !== null ? Math.max(tStart, currentAnimTime - TRAIL_DAYS_MS) : tStart;
+        elements.timeStartVal.innerText = formatTime(tStart);
+        elements.timeEndVal.innerText = formatTime(tEnd);
 
-    // 1. Zero-Allocation TypedArray Masking
-    for (let i = 0; i < 11; i++) {
-        const bin = renderCache.bins[i];
-        const viewLats = bin.workingLats;
-        const viewLons = bin.workingLons;
-        
-        // Instant C-level memory copy instead of GC allocation
-        viewLats.set(bin.f32Lats);
-        viewLons.set(bin.f32Lons);
-        
-        const times = bin.f64Times;
-        const len = times.length;
-        
-        for (let j = 0; j < len; j++) {
+        const restyleLat = [];
+        const restyleLon = [];
+        const limitTime = currentAnimTime !== null ? currentAnimTime : tEnd;
+        const tailTime =
+          currentAnimTime !== null
+            ? Math.max(tStart, currentAnimTime - TRAIL_DAYS_MS)
+            : tStart;
+
+        // 1. Zero-Allocation TypedArray Masking
+        for (let i = 0; i < 11; i++) {
+          const bin = renderCache.bins[i];
+          const viewLats = bin.workingLats;
+          const viewLons = bin.workingLons;
+
+          // Instant C-level memory copy instead of GC allocation
+          viewLats.set(bin.f32Lats);
+          viewLons.set(bin.f32Lons);
+
+          const times = bin.f64Times;
+          const len = times.length;
+
+          for (let j = 0; j < len; j++) {
             const t = times[j];
             if (t > limitTime || t < tailTime) {
-                viewLats[j] = NaN;
-                viewLons[j] = NaN;
+              viewLats[j] = NaN;
+              viewLons[j] = NaN;
             }
+          }
+          restyleLat.push(viewLats);
+          restyleLon.push(viewLons);
         }
-        restyleLat.push(viewLats);
-        restyleLon.push(viewLons);
-    }
 
-    // 2. Compute Active Heads
-    const curLats = [], curLons = [], curColors = [], curTexts = [];
-    
-    if (currentAnimTime !== null) {
-        for (let i = 0; i < activeTrackIndices.length; i++) {
+        // 2. Compute Active Heads
+        const curLats = [],
+          curLons = [],
+          curColors = [],
+          curTexts = [];
+
+        if (currentAnimTime !== null) {
+          for (let i = 0; i < activeTrackIndices.length; i++) {
             const t = allData.tracks[activeTrackIndices[i]];
-            if (masterTimes[t.start] <= limitTime && masterTimes[t.end] >= limitTime) {
-                let headIdx = -1;
-                // Fast reverse scan (O(1) amortized since limitTime is usually near the end)
-                for (let p = t.end; p >= t.start; p--) {
-                    if (masterTimes[p] <= limitTime) {
-                        headIdx = p;
-                        break;
-                    }
+            if (
+              masterTimes[t.start] <= limitTime &&
+              masterTimes[t.end] >= limitTime
+            ) {
+              let headIdx = -1;
+              // Fast reverse scan (O(1) amortized since limitTime is usually near the end)
+              for (let p = t.end; p >= t.start; p--) {
+                if (masterTimes[p] <= limitTime) {
+                  headIdx = p;
+                  break;
                 }
-                if (headIdx !== -1 && masterTimes[headIdx] >= tailTime) {
-                    curLats.push(masterLats[headIdx]);
-                    curLons.push(masterLons[headIdx]);
-                    curColors.push(getColor(masterStrengths[headIdx], isMSL, cmin, cmax));
-                    curTexts.push(masterHoverTexts[headIdx]);
-                }
+              }
+              if (headIdx !== -1 && masterTimes[headIdx] >= tailTime) {
+                curLats.push(masterLats[headIdx]);
+                curLons.push(masterLons[headIdx]);
+                curColors.push(
+                  getColor(masterStrengths[headIdx], isMSL, cmin, cmax),
+                );
+                curTexts.push(masterHoverTexts[headIdx]);
+              }
             }
+          }
         }
-    }
-    restyleLat.push(curLats);
-    restyleLon.push(curLons);
+        restyleLat.push(curLats);
+        restyleLon.push(curLons);
 
-    elements.status.innerText = (isPlaying || currentAnimTime !== null) ? `Animating: ${formatTime(currentAnimTime)}` : `Showing ${activeTrackIndices.length} tracks`;
-    elements.status.style.color = (isPlaying || currentAnimTime !== null) ? "#dc3545" : "#666";
+        elements.status.innerText =
+          isPlaying || currentAnimTime !== null
+            ? `Animating: ${formatTime(currentAnimTime)}`
+            : `Showing ${activeTrackIndices.length} tracks`;
+        elements.status.style.color =
+          isPlaying || currentAnimTime !== null ? "#dc3545" : "#666";
 
-    // 3. Render
-    if (forceStructural || !tracesInitialized) {
-        tracesInitialized = true;
-        const traces = [];
-        
-        TURBO_SCALE.forEach((bin, idx) => {
-            const color = `rgb(${bin[1].join(',')})`;
+        // 3. Render
+        if (forceStructural || !tracesInitialized) {
+          tracesInitialized = true;
+          const traces = [];
+
+          TURBO_SCALE.forEach((bin, idx) => {
+            const color = `rgb(${bin[1].join(",")})`;
             traces.push({
-                type: 'scattergeo', mode: 'lines+markers', lat: restyleLat[idx], lon: restyleLon[idx],
-                line: { color: color, width: 1.5 },
-                marker: { size: 1, color: 'rgba(0,0,0,0)', line: {width: 0} }, 
-                hovertext: renderCache.bins[idx].texts,
-                hovertemplate: '%{hovertext}<extra></extra>',
-                hoverlabel: { bgcolor: renderCache.bins[idx].colors, bordercolor: '#fff' },
-                showlegend: false
+              type: "scattergeo",
+              mode: "lines+markers",
+              lat: restyleLat[idx],
+              lon: restyleLon[idx],
+              line: { color: color, width: 1.5 },
+              marker: { size: 1, color: "rgba(0,0,0,0)", line: { width: 0 } },
+              hovertext: renderCache.bins[idx].texts,
+              hovertemplate: "%{hovertext}<extra></extra>",
+              hoverlabel: {
+                bgcolor: renderCache.bins[idx].colors,
+                bordercolor: "#fff",
+              },
+              showlegend: false,
             });
-        });
-        
-        traces.push({ 
-            type: 'scattergeo', mode: 'markers', lat: curLats, lon: curLons, 
-            marker: { size: 10, color: curColors, line: { width: 1.5, color: '#333' } }, 
-            hovertext: curTexts,
-            hovertemplate: '%{hovertext}<extra></extra>',
-            hoverlabel: { bgcolor: curColors, bordercolor: '#fff' },
-            showlegend: false 
-        });
+          });
 
-        const layout = {
-            margin: { l: 20, r: 20, t: 20, b: 20 }, height: plotHeight,
-            geo: { 
-                showcoastlines: true, coastlinecolor: "#444", showland: true, landcolor: "#eee", showocean: true, oceancolor: "#fff", 
-                projection: { type: proj }
+          traces.push({
+            type: "scattergeo",
+            mode: "markers",
+            lat: curLats,
+            lon: curLons,
+            marker: {
+              size: 10,
+              color: curColors,
+              line: { width: 1.5, color: "#333" },
             },
-            hovermode: 'closest',
-            uirevision: proj
-        };
-        if (proj === 'orthographic') layout.geo.projection.rotation = { lon: -60, lat: 35 };
+            hovertext: curTexts,
+            hovertemplate: "%{hovertext}<extra></extra>",
+            hoverlabel: { bgcolor: curColors, bordercolor: "#fff" },
+            showlegend: false,
+          });
 
-        Plotly.react(elements.plot, traces, layout, {responsive: true, displayModeBar: false}).then(() => { isUpdating = false; });
-    } else {
-        // High-Performance Temporal Update
-        // Only pass lat/lon for the 11 bins. 
-        // We do not pass text/colors because they never change structure, we just mask the points via lat/lon.
-        const update = {
-            lat: restyleLat,
-            lon: restyleLon
-        };
-        
-        Plotly.restyle(elements.plot, update, Array.from(Array(12).keys())).then(() => {
-            // For the 12th trace (active markers), we must pass text/colors because its array dynamically resizes.
-            const dynamicUpdate = {
-                hovertext: [curTexts],
-                'marker.color': [curColors],
-                'hoverlabel.bgcolor': [curColors]
-            };
-            return Plotly.restyle(elements.plot, dynamicUpdate, [11]);
-        }).then(() => {
+          const layout = {
+            margin: { l: 20, r: 20, t: 20, b: 20 },
+            height: plotHeight,
+            geo: {
+              showcoastlines: true,
+              coastlinecolor: "#444",
+              showland: true,
+              landcolor: "#eee",
+              showocean: true,
+              oceancolor: "#fff",
+              projection: { type: proj },
+            },
+            hovermode: "closest",
+            uirevision: proj,
+          };
+          if (proj === "orthographic")
+            layout.geo.projection.rotation = { lon: -60, lat: 35 };
+
+          Plotly.react(elements.plot, traces, layout, {
+            responsive: true,
+            displayModeBar: false,
+          }).then(() => {
             isUpdating = false;
-        });
-    }
-}
+          });
+        } else {
+          // High-Performance Temporal Update
+          // Only pass lat/lon for the 11 bins.
+          // We do not pass text/colors because they never change structure, we just mask the points via lat/lon.
+          const update = {
+            lat: restyleLat,
+            lon: restyleLon,
+          };
 
-init();
-</script>
-</body>
+          Plotly.restyle(elements.plot, update, Array.from(Array(12).keys()))
+            .then(() => {
+              // For the 12th trace (active markers), we must pass text/colors because its array dynamically resizes.
+              const dynamicUpdate = {
+                hovertext: [curTexts],
+                "marker.color": [curColors],
+                "hoverlabel.bgcolor": [curColors],
+              };
+              return Plotly.restyle(elements.plot, dynamicUpdate, [11]);
+            })
+            .then(() => {
+              isUpdating = false;
+            });
+        }
+      }
+
+      init();
+    </script>
+  </body>
 </html>

--- a/src/pystormtracker/templates/explorer.html
+++ b/src/pystormtracker/templates/explorer.html
@@ -1,802 +1,1314 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Interactive Storm Tracks</title>
     <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
     <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; margin: 0; padding: 10px; color: #333; }
-        .controls { 
-            display: grid; 
-            grid-template-columns: repeat(4, 1fr); 
-            gap: 15px; 
-            background: #f8f9fa; 
-            padding: 15px; 
-            border-radius: 8px; 
-            border: 1px solid #ddd; 
-            margin-bottom: 10px; 
-        }
-        
-        .control-group.playback-group { grid-column: 1 / -1; }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+          sans-serif;
+        margin: 0;
+        padding: 10px;
+        color: #333;
+      }
+      .controls {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 15px;
+        background: #f8f9fa;
+        padding: 15px;
+        border-radius: 8px;
+        border: 1px solid #ddd;
+        margin-bottom: 10px;
+      }
 
-        @media (max-width: 900px) {
-            .controls { grid-template-columns: 1fr 1fr; }
-        }
+      .control-group.playback-group {
+        grid-column: 1 / -1;
+      }
 
-        @media (max-width: 600px) {
-            .controls { gap: 8px; padding: 10px; }
-            body { padding: 5px; }
-            .control-group label { margin-bottom: 2px; font-size: 0.8em; }
-            input[type="range"] { height: 4px; margin: 4px 0; }
-            input[type="range"]::-webkit-slider-thumb { width: 14px; height: 14px; }
-            .range-slider { height: 16px; }
-            .title-bar { margin-bottom: 5px; }
-            .title-bar h2 { font-size: 1.1em; }
-            .btn { padding: 4px 6px; font-size: 0.75em; }
-            .slider-values { font-size: 0.7em; }
-            .color-scale { width: 40px !important; }
-            .color-scale-labels { font-size: 8px !important; }
+      @media (max-width: 900px) {
+        .controls {
+          grid-template-columns: 1fr 1fr;
         }
+      }
 
-        .control-group { display: flex; flex-direction: column; }
-        .control-group label { font-weight: bold; margin-bottom: 5px; font-size: 0.9em; }
-        .slider-values { display: flex; justify-content: space-between; font-size: 0.8em; color: #666; margin-top: 2px; }
-        
-        .plot-container { position: relative; width: 100%; height: 700px; border: 1px solid #eee; border-radius: 8px; display: flex; }
-        #plot-wrapper { flex: 1; position: relative; height: 100%; overflow: hidden; }
-        #plot { width: 100%; height: 100%; }
-        
-        .color-scale { 
-            width: 60px; 
-            height: 100%; 
-            display: flex; 
-            flex-direction: column; 
-            align-items: center; 
-            padding: 40px 0; 
-            font-size: 10px; 
-            color: #666;
-            background: #fff;
-            border-right: 1px solid #eee;
-            border-radius: 8px 0 0 8px;
-            box-sizing: border-box;
+      @media (max-width: 600px) {
+        .controls {
+          gap: 8px;
+          padding: 10px;
         }
-        .color-bar-wrapper { flex: 1; display: flex; flex-direction: row; gap: 4px; }
-        .color-bar { 
-            width: 12px; 
-            height: 100%; 
-            background: linear-gradient(to bottom, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1));
-            border-radius: 6px;
+        body {
+          padding: 5px;
         }
-        .color-scale-labels { height: 100%; display: flex; flex-direction: column; justify-content: space-between; align-items: flex-start; }
-
-        select { width: 100%; cursor: pointer; padding: 4px; border-radius: 4px; border: 1px solid #ccc; background: #fff; height: auto; font-size: 0.9em; }
-        
-        input[type="range"] { width: 100%; cursor: pointer; -webkit-appearance: none; background: #ddd; height: 6px; border-radius: 3px; outline: none; margin: 10px 0; }
-        input[type="range"]::-webkit-slider-thumb { -webkit-appearance: none; width: 16px; height: 16px; background: #007bff; border-radius: 50%; cursor: pointer; border: 1px solid #0056b3; position: relative; z-index: 2; }
-        
-        #time-scrub::-webkit-slider-thumb { width: 16px; height: 26px; background: linear-gradient(to right, transparent 6px, #dc3545 6px, #dc3545 10px, transparent 10px); border-radius: 0; border: none; cursor: ew-resize; z-index: 3; -webkit-appearance: none; transition: opacity 0.2s; }
-        #time-scrub::-moz-range-thumb { width: 16px; height: 26px; background: linear-gradient(to right, transparent 6px, #dc3545 6px, #dc3545 10px, transparent 10px); border-radius: 0; border: none; cursor: ew-resize; z-index: 3; transition: opacity 0.2s; }
-
-        .range-slider.not-animating #time-scrub::-webkit-slider-thumb { opacity: 0; cursor: default; }
-        .range-slider.not-animating #time-scrub::-moz-range-thumb { opacity: 0; cursor: default; }
-
-        .range-slider { position: relative; width: 100%; height: 30px; display: flex; align-items: center; }
-        .range-slider input[type="range"] { position: absolute; left: 0; margin: 0; pointer-events: none; background: none; top: 50%; transform: translateY(-50%); }
-        .range-slider input[type="range"]::-webkit-slider-thumb { pointer-events: auto; }
-        .range-slider input[type="range"]::-moz-range-thumb { pointer-events: auto; }
-        .range-slider .slider-track { 
-            position: absolute; height: 6px; width: 100%; background: #ddd; border-radius: 3px; top: 50%; transform: translateY(-50%); z-index: 0; 
-            --p1: 0; --p2: 1; --ps: 0; --pt: 0;
-            --c1: calc(8px + var(--p1) * (100% - 16px));
-            --c2: calc(8px + var(--p2) * (100% - 16px));
-            --cs: calc(8px + var(--ps) * (100% - 16px));
-            --ct: calc(8px + var(--pt) * (100% - 16px));
-            background: linear-gradient(to right, #ddd 0%, #ddd var(--c1), #99c7ff var(--c1), #99c7ff var(--ct), #007bff var(--ct), #007bff var(--cs), #99c7ff var(--cs), #99c7ff var(--c2), #ddd var(--c2), #ddd 100%);
+        .control-group label {
+          margin-bottom: 2px;
+          font-size: 0.8em;
         }
-        
-        .title-bar { margin-bottom: 10px; border-left: 4px solid #007bff; padding-left: 10px; display: flex; align-items: baseline; justify-content: space-between; padding-right: 15px; }
-        .title-bar h2 { margin: 0; font-size: 1.2em; }
-        .title-bar .version { font-size: 0.85em; color: #666; font-family: monospace; }
-        .loading { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: rgba(255,255,255,0.8); padding: 20px; border-radius: 10px; z-index: 100; font-weight: bold; }
-        .btn { padding: 5px 10px; border: 1px solid #ccc; border-radius: 4px; background: #fff; cursor: pointer; text-align: center; }
-        .btn:hover:not(:disabled) { background: #e9ecef; }
-        .btn:disabled { opacity: 0.5; cursor: not-allowed; }
-        
-        #fps-display { position: absolute; top: 10px; right: 10px; background: rgba(0,0,0,0.5); color: white; padding: 2px 5px; border-radius: 3px; font-size: 10px; z-index: 1000; pointer-events: none; display: none; }
-        #fps-toggle { position: absolute; top: 0; right: 0; width: 100px; height: 100px; z-index: 1001; cursor: default; }
+        input[type="range"] {
+          height: 4px;
+          margin: 4px 0;
+        }
+        input[type="range"]::-webkit-slider-thumb {
+          width: 14px;
+          height: 14px;
+        }
+        .range-slider {
+          height: 16px;
+        }
+        .title-bar {
+          margin-bottom: 5px;
+        }
+        .title-bar h2 {
+          font-size: 1.1em;
+        }
+        .btn {
+          padding: 4px 6px;
+          font-size: 0.75em;
+        }
+        .slider-values {
+          font-size: 0.7em;
+        }
+        .color-scale {
+          width: 40px !important;
+        }
+        .color-scale-labels {
+          font-size: 8px !important;
+        }
+      }
+
+      .control-group {
+        display: flex;
+        flex-direction: column;
+      }
+      .control-group label {
+        font-weight: bold;
+        margin-bottom: 5px;
+        font-size: 0.9em;
+      }
+      .slider-values {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.8em;
+        color: #666;
+        margin-top: 2px;
+      }
+
+      .plot-container {
+        position: relative;
+        width: 100%;
+        height: 700px;
+        border: 1px solid #eee;
+        border-radius: 8px;
+        display: flex;
+      }
+      #plot-wrapper {
+        flex: 1;
+        position: relative;
+        height: 100%;
+        overflow: hidden;
+      }
+      #plot {
+        width: 100%;
+        height: 100%;
+      }
+
+      .color-scale {
+        width: 60px;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 40px 0;
+        font-size: 10px;
+        color: #666;
+        background: #fff;
+        border-right: 1px solid #eee;
+        border-radius: 8px 0 0 8px;
+        box-sizing: border-box;
+      }
+      .color-bar-wrapper {
+        flex: 1;
+        display: flex;
+        flex-direction: row;
+        gap: 4px;
+      }
+      .color-bar {
+        width: 12px;
+        height: 100%;
+        background: linear-gradient(
+          to bottom,
+          rgb(48, 18, 59),
+          rgb(70, 74, 164),
+          rgb(61, 126, 237),
+          rgb(33, 176, 213),
+          rgb(24, 215, 160),
+          rgb(100, 240, 91),
+          rgb(178, 230, 54),
+          rgb(238, 182, 48),
+          rgb(254, 112, 28),
+          rgb(226, 45, 6),
+          rgb(158, 1, 1)
+        );
+        border-radius: 6px;
+      }
+      .color-scale-labels {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: flex-start;
+      }
+
+      select {
+        width: 100%;
+        cursor: pointer;
+        padding: 4px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        background: #fff;
+        height: auto;
+        font-size: 0.9em;
+      }
+
+      input[type="range"] {
+        width: 100%;
+        cursor: pointer;
+        -webkit-appearance: none;
+        background: #ddd;
+        height: 6px;
+        border-radius: 3px;
+        outline: none;
+        margin: 10px 0;
+      }
+      input[type="range"]::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        width: 16px;
+        height: 16px;
+        background: #007bff;
+        border-radius: 50%;
+        cursor: pointer;
+        border: 1px solid #0056b3;
+        position: relative;
+        z-index: 2;
+      }
+
+      #time-scrub::-webkit-slider-thumb {
+        width: 16px;
+        height: 26px;
+        background: linear-gradient(
+          to right,
+          transparent 6px,
+          #dc3545 6px,
+          #dc3545 10px,
+          transparent 10px
+        );
+        border-radius: 0;
+        border: none;
+        cursor: ew-resize;
+        z-index: 3;
+        -webkit-appearance: none;
+        transition: opacity 0.2s;
+      }
+      #time-scrub::-moz-range-thumb {
+        width: 16px;
+        height: 26px;
+        background: linear-gradient(
+          to right,
+          transparent 6px,
+          #dc3545 6px,
+          #dc3545 10px,
+          transparent 10px
+        );
+        border-radius: 0;
+        border: none;
+        cursor: ew-resize;
+        z-index: 3;
+        transition: opacity 0.2s;
+      }
+
+      .range-slider.not-animating #time-scrub::-webkit-slider-thumb {
+        opacity: 0;
+        cursor: default;
+      }
+      .range-slider.not-animating #time-scrub::-moz-range-thumb {
+        opacity: 0;
+        cursor: default;
+      }
+
+      .range-slider {
+        position: relative;
+        width: 100%;
+        height: 30px;
+        display: flex;
+        align-items: center;
+      }
+      .range-slider input[type="range"] {
+        position: absolute;
+        left: 0;
+        margin: 0;
+        pointer-events: none;
+        background: none;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+      .range-slider input[type="range"]::-webkit-slider-thumb {
+        pointer-events: auto;
+      }
+      .range-slider input[type="range"]::-moz-range-thumb {
+        pointer-events: auto;
+      }
+      .range-slider .slider-track {
+        position: absolute;
+        height: 6px;
+        width: 100%;
+        background: #ddd;
+        border-radius: 3px;
+        top: 50%;
+        transform: translateY(-50%);
+        z-index: 0;
+        --p1: 0;
+        --p2: 1;
+        --ps: 0;
+        --pt: 0;
+        --c1: calc(8px + var(--p1) * (100% - 16px));
+        --c2: calc(8px + var(--p2) * (100% - 16px));
+        --cs: calc(8px + var(--ps) * (100% - 16px));
+        --ct: calc(8px + var(--pt) * (100% - 16px));
+        background: linear-gradient(
+          to right,
+          #ddd 0%,
+          #ddd var(--c1),
+          #99c7ff var(--c1),
+          #99c7ff var(--ct),
+          #007bff var(--ct),
+          #007bff var(--cs),
+          #99c7ff var(--cs),
+          #99c7ff var(--c2),
+          #ddd var(--c2),
+          #ddd 100%
+        );
+      }
+
+      .title-bar {
+        margin-bottom: 10px;
+        border-left: 4px solid #007bff;
+        padding-left: 10px;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        padding-right: 15px;
+      }
+      .title-bar h2 {
+        margin: 0;
+        font-size: 1.2em;
+      }
+      .title-bar .version {
+        font-size: 0.85em;
+        color: #666;
+        font-family: monospace;
+      }
+      .loading {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: rgba(255, 255, 255, 0.8);
+        padding: 20px;
+        border-radius: 10px;
+        z-index: 100;
+        font-weight: bold;
+      }
+      .btn {
+        padding: 5px 10px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #fff;
+        cursor: pointer;
+        text-align: center;
+      }
+      .btn:hover:not(:disabled) {
+        background: #e9ecef;
+      }
+      .btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      #fps-display {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: rgba(0, 0, 0, 0.5);
+        color: white;
+        padding: 2px 5px;
+        border-radius: 3px;
+        font-size: 10px;
+        z-index: 1000;
+        pointer-events: none;
+        display: none;
+      }
+      #fps-toggle {
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 100px;
+        height: 100px;
+        z-index: 1001;
+        cursor: default;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
+    <div id="loading" class="loading">Loading track data...</div>
 
-<div id="loading" class="loading">Loading track data...</div>
+    <div class="title-bar">
+      <h2>Storm Track Explorer</h2>
+      <span class="version">PyStormTracker {{version}}</span>
+    </div>
 
-<div class="title-bar">
-    <h2>Storm Track Explorer</h2>
-    <span class="version">PyStormTracker {{version}}</span>
-</div>
+    // TRACKS_DATA_PLACEHOLDER
 
-// TRACKS_DATA_PLACEHOLDER
-
-<div class="controls">
-    <div class="control-group">
+    <div class="controls">
+      <div class="control-group">
         <label>Map Projection</label>
         <select id="projection">
-            <option value="orthographic">Globe (3D)</option>
-            <option value="equirectangular">Global (Lat/Lon)</option>
+          <option value="orthographic">Globe (3D)</option>
+          <option value="equirectangular">Global (Lat/Lon)</option>
         </select>
-    </div>
-    <div class="control-group">
+      </div>
+      <div class="control-group">
         <label id="strength-label">Peak Strength</label>
-        <input type="range" id="strength">
+        <input type="range" id="strength" />
         <div class="slider-values">
-            <span id="strength-min-val">...</span>
-            <span id="strength-val">...</span>
-            <span id="strength-max-val">...</span>
+          <span id="strength-min-val">...</span>
+          <span id="strength-val">...</span>
+          <span id="strength-max-val">...</span>
         </div>
-    </div>
-    <div class="control-group">
+      </div>
+      <div class="control-group">
         <label>Min Duration (hours)</label>
-        <input type="range" id="duration" step="6">
+        <input type="range" id="duration" step="6" />
         <div class="slider-values">
-            <span>0h</span>
-            <span id="duration-val">42h</span>
-            <span id="duration-max-val">...</span>
+          <span>0h</span>
+          <span id="duration-val">42h</span>
+          <span id="duration-max-val">...</span>
         </div>
-    </div>
-    <div class="control-group">
+      </div>
+      <div class="control-group">
         <label>Min Displacement (km)</label>
-        <input type="range" id="displacement" step="100">
+        <input type="range" id="displacement" step="100" />
         <div class="slider-values">
-            <span id="displacement-min-val">100km</span>
-            <span id="displacement-val">...</span>
-            <span id="displacement-max-val">...</span>
+          <span id="displacement-min-val">100km</span>
+          <span id="displacement-val">...</span>
+          <span id="displacement-max-val">...</span>
         </div>
-    </div>
-    <div class="control-group playback-group">
+      </div>
+      <div class="control-group playback-group">
         <label>Time Range</label>
         <div class="range-slider">
-            <div class="slider-track" id="time-track"></div>
-            <input type="range" id="time-start" step="21600000">
-            <input type="range" id="time-end" step="21600000">
-            <input type="range" id="time-scrub" step="21600000">
+          <div class="slider-track" id="time-track"></div>
+          <input type="range" id="time-start" step="21600000" />
+          <input type="range" id="time-end" step="21600000" />
+          <input type="range" id="time-scrub" step="21600000" />
         </div>
         <div class="slider-values">
-            <span id="time-start-val">...</span>
-            <span id="status" style="color: #dc3545; font-weight: bold; position: absolute; left: 50%; transform: translateX(-50%); white-space: nowrap;">Initializing...</span>
-            <span id="time-end-val">...</span>
+          <span id="time-start-val">...</span>
+          <span
+            id="status"
+            style="
+              color: #dc3545;
+              font-weight: bold;
+              position: absolute;
+              left: 50%;
+              transform: translateX(-50%);
+              white-space: nowrap;
+            "
+            >Initializing...</span
+          >
+          <span id="time-end-val">...</span>
         </div>
-        <div style="display:flex; gap:10px; margin-top:10px; align-items: center; justify-content: center;">
-            <button id="btn-play-pause" class="btn" style="flex: 2;">Play</button>
-            <div style="flex: 1.5; max-width: 180px; display: flex; align-items: center; justify-content: center; gap: 8px;">
-                <label style="display:flex; align-items:center; gap:2px; font-size:0.85em; cursor:pointer; white-space: nowrap;">
-                    <input type="checkbox" id="chk-loop"> Loop
-                </label>
-                <div style="display:flex; border:1px solid #ccc; border-radius:4px; overflow:hidden; background:#fff; height: 26px; flex: 1; min-width: 90px;">
-                    <button id="btn-speed-down" class="btn" style="border:none; border-radius:0; padding: 0; background:none; flex: 1;">-</button>
-                    <div id="speed-val" style="display:flex; align-items:center; justify-content:center; font-size:0.85em; font-weight:bold; border-left:1px solid #eee; border-right:1px solid #eee; flex: 1.5;">1x</div>
-                    <button id="btn-speed-up" class="btn" style="border:none; border-radius:0; padding: 0; background:none; flex: 1;">+</button>
-                </div>
+        <div
+          style="
+            display: flex;
+            gap: 10px;
+            margin-top: 10px;
+            align-items: center;
+            justify-content: center;
+          "
+        >
+          <button id="btn-play-pause" class="btn" style="flex: 2">Play</button>
+          <div
+            style="
+              flex: 1.5;
+              max-width: 180px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              gap: 8px;
+            "
+          >
+            <label
+              style="
+                display: flex;
+                align-items: center;
+                gap: 2px;
+                font-size: 0.85em;
+                cursor: pointer;
+                white-space: nowrap;
+              "
+            >
+              <input type="checkbox" id="chk-loop" /> Loop
+            </label>
+            <div
+              style="
+                display: flex;
+                border: 1px solid #ccc;
+                border-radius: 4px;
+                overflow: hidden;
+                background: #fff;
+                height: 26px;
+                flex: 1;
+                min-width: 90px;
+              "
+            >
+              <button
+                id="btn-speed-down"
+                class="btn"
+                style="
+                  border: none;
+                  border-radius: 0;
+                  padding: 0;
+                  background: none;
+                  flex: 1;
+                "
+              >
+                -
+              </button>
+              <div
+                id="speed-val"
+                style="
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  font-size: 0.85em;
+                  font-weight: bold;
+                  border-left: 1px solid #eee;
+                  border-right: 1px solid #eee;
+                  flex: 1.5;
+                "
+              >
+                1x
+              </div>
+              <button
+                id="btn-speed-up"
+                class="btn"
+                style="
+                  border: none;
+                  border-radius: 0;
+                  padding: 0;
+                  background: none;
+                  flex: 1;
+                "
+              >
+                +
+              </button>
             </div>
-            <button id="btn-reset" class="btn" style="flex: 2;">Reset</button>
+          </div>
+          <button id="btn-reset" class="btn" style="flex: 2">Reset</button>
         </div>
+      </div>
     </div>
-</div>
 
-<div class="plot-container">
-    <div class="color-scale" id="legend">
-        <div style="font-weight: bold; margin-bottom: 12px; font-size: 11px;" id="legend-unit">hPa</div>
-        <div class="color-bar-wrapper">
-            <div class="color-bar" id="legend-bar"></div>
-            <div class="color-scale-labels" id="legend-labels">
-                <span>0</span>
-                <span>-30</span>
-                <span>-60</span>
-            </div>
+    <div class="plot-container">
+      <div class="color-scale" id="legend">
+        <div
+          style="font-weight: bold; margin-bottom: 12px; font-size: 11px"
+          id="legend-unit"
+        >
+          hPa
         </div>
-    </div>
-    <div id="plot-wrapper">
+        <div class="color-bar-wrapper">
+          <div class="color-bar" id="legend-bar"></div>
+          <div class="color-scale-labels" id="legend-labels">
+            <span>0</span>
+            <span>-30</span>
+            <span>-60</span>
+          </div>
+        </div>
+      </div>
+      <div id="plot-wrapper">
         <div id="plot"></div>
         <div id="fps-display">FPS: --</div>
         <div id="fps-toggle"></div>
+      </div>
     </div>
-</div>
 
-<script>
-// Global Constants
-const TURBO_SCALE = [[0.0, [48, 18, 59]], [0.1, [70, 74, 164]], [0.2, [61, 126, 237]], [0.3, [33, 176, 213]], [0.4, [24, 215, 160]], [0.5, [100, 240, 91]], [0.6, [178, 230, 54]], [0.7, [238, 182, 48]], [0.8, [254, 112, 28]], [0.9, [226, 45, 6]], [1.0, [158, 1, 1]]];
-const BASE_STEPS_PER_SEC = 24; 
-const HOUR_MS = 21600000; 
-const SPEEDS = [0.25, 0.5, 1, 2, 4];
-const TRAIL_DAYS_MS = 15 * 24 * 3600 * 1000;
+    <script>
+      // Global Constants
+      const TURBO_SCALE = [
+        [0.0, [48, 18, 59]],
+        [0.1, [70, 74, 164]],
+        [0.2, [61, 126, 237]],
+        [0.3, [33, 176, 213]],
+        [0.4, [24, 215, 160]],
+        [0.5, [100, 240, 91]],
+        [0.6, [178, 230, 54]],
+        [0.7, [238, 182, 48]],
+        [0.8, [254, 112, 28]],
+        [0.9, [226, 45, 6]],
+        [1.0, [158, 1, 1]],
+      ];
+      const BASE_STEPS_PER_SEC = 24;
+      const HOUR_MS = 21600000;
+      const SPEEDS = [0.25, 0.5, 1, 2, 4];
+      const TRAIL_DAYS_MS = 15 * 24 * 3600 * 1000;
 
-// State Variables
-let allData = null;
-let isPlaying = false;
-let currentAnimTime = null;
-let isUpdating = false;
-let isDraggingMap = false;
-let lastFrameTime = 0;
-let lastProj = null;
-let speedIdx = 2; 
-let tracesInitialized = false;
+      // State Variables
+      let allData = null;
+      let isPlaying = false;
+      let currentAnimTime = null;
+      let isUpdating = false;
+      let isDraggingMap = false;
+      let lastFrameTime = 0;
+      let lastProj = null;
+      let speedIdx = 2;
+      let tracesInitialized = false;
 
-// Benchmark
-let frameCount = 0;
-let lastFpsUpdate = 0;
+      // Benchmark
+      let frameCount = 0;
+      let lastFpsUpdate = 0;
 
-// Buffer & Cache Data
-let masterLats, masterLons, masterTimes, masterStrengths, masterHoverTexts;
-let activeTrackIndices = [];
-let renderCache = { built: false, bins: [] };
+      // Buffer & Cache Data
+      let masterLats,
+        masterLons,
+        masterTimes,
+        masterStrengths,
+        masterHoverTexts;
+      let activeTrackIndices = [];
+      let renderCache = { built: false, bins: [] };
 
-const elements = {
-    projection: document.getElementById('projection'),
-    timeStart: document.getElementById('time-start'),
-    timeEnd: document.getElementById('time-end'),
-    timeTrack: document.getElementById('time-track'),
-    timeStartVal: document.getElementById('time-start-val'),
-    timeEndVal: document.getElementById('time-end-val'),
-    timeScrub: document.getElementById('time-scrub'),
-    btnPlayPause: document.getElementById('btn-play-pause'),
-    btnSpeedDown: document.getElementById('btn-speed-down'),
-    btnSpeedUp: document.getElementById('btn-speed-up'),
-    speedVal: document.getElementById('speed-val'),
-    chkLoop: document.getElementById('chk-loop'),
-    btnReset: document.getElementById('btn-reset'),
-    strength: document.getElementById('strength'),
-    strengthLabel: document.getElementById('strength-label'),
-    strengthVal: document.getElementById('strength-val'),
-    strengthMinVal: document.getElementById('strength-min-val'),
-    strengthMaxVal: document.getElementById('strength-max-val'),
-    duration: document.getElementById('duration'),
-    durationVal: document.getElementById('duration-val'),
-    durationMaxVal: document.getElementById('duration-max-val'),
-    displacement: document.getElementById('displacement'),
-    displacementVal: document.getElementById('displacement-val'),
-    displacementMinVal: document.getElementById('displacement-min-val'),
-    displacementMaxVal: document.getElementById('displacement-max-val'),
-    status: document.getElementById('status'),
-    loading: document.getElementById('loading'),
-    plot: document.getElementById('plot'),
-    fpsDisplay: document.getElementById('fps-display'),
-    fpsToggle: document.getElementById('fps-toggle'),
-    legendUnit: document.getElementById('legend-unit'),
-    legendBar: document.getElementById('legend-bar'),
-    legendLabels: document.getElementById('legend-labels')
-};
+      const elements = {
+        projection: document.getElementById("projection"),
+        timeStart: document.getElementById("time-start"),
+        timeEnd: document.getElementById("time-end"),
+        timeTrack: document.getElementById("time-track"),
+        timeStartVal: document.getElementById("time-start-val"),
+        timeEndVal: document.getElementById("time-end-val"),
+        timeScrub: document.getElementById("time-scrub"),
+        btnPlayPause: document.getElementById("btn-play-pause"),
+        btnSpeedDown: document.getElementById("btn-speed-down"),
+        btnSpeedUp: document.getElementById("btn-speed-up"),
+        speedVal: document.getElementById("speed-val"),
+        chkLoop: document.getElementById("chk-loop"),
+        btnReset: document.getElementById("btn-reset"),
+        strength: document.getElementById("strength"),
+        strengthLabel: document.getElementById("strength-label"),
+        strengthVal: document.getElementById("strength-val"),
+        strengthMinVal: document.getElementById("strength-min-val"),
+        strengthMaxVal: document.getElementById("strength-max-val"),
+        duration: document.getElementById("duration"),
+        durationVal: document.getElementById("duration-val"),
+        durationMaxVal: document.getElementById("duration-max-val"),
+        displacement: document.getElementById("displacement"),
+        displacementVal: document.getElementById("displacement-val"),
+        displacementMinVal: document.getElementById("displacement-min-val"),
+        displacementMaxVal: document.getElementById("displacement-max-val"),
+        status: document.getElementById("status"),
+        loading: document.getElementById("loading"),
+        plot: document.getElementById("plot"),
+        fpsDisplay: document.getElementById("fps-display"),
+        fpsToggle: document.getElementById("fps-toggle"),
+        legendUnit: document.getElementById("legend-unit"),
+        legendBar: document.getElementById("legend-bar"),
+        legendLabels: document.getElementById("legend-labels"),
+      };
 
-function formatTime(ms) {
-    if (!ms || isNaN(ms)) return "N/A";
-    return new Date(ms).toISOString().slice(0, 16).replace('T', ' ');
-}
+      function formatTime(ms) {
+        if (!ms || isNaN(ms)) return "N/A";
+        return new Date(ms).toISOString().slice(0, 16).replace("T", " ");
+      }
 
-function getColor(val, isMSL, cmin, cmax) {
-    let t = Math.min(1, Math.max(0, (val - cmin) / (cmax - cmin)));
-    const tc = isMSL ? (1 - t) : t;
-    for (let i = 0; i < TURBO_SCALE.length - 1; i++) {
-        if (tc >= TURBO_SCALE[i][0] && tc <= TURBO_SCALE[i+1][0]) {
-            const ratio = (tc - TURBO_SCALE[i][0]) / (TURBO_SCALE[i+1][0] - TURBO_SCALE[i][0]);
-            const r = Math.round(TURBO_SCALE[i][1][0] + (TURBO_SCALE[i+1][1][0] - TURBO_SCALE[i][1][0]) * ratio);
-            const g = Math.round(TURBO_SCALE[i][1][1] + (TURBO_SCALE[i+1][1][1] - TURBO_SCALE[i][1][1]) * ratio);
-            const b = Math.round(TURBO_SCALE[i][1][2] + (TURBO_SCALE[i+1][1][2] - TURBO_SCALE[i][1][2]) * ratio);
+      function getColor(val, isMSL, cmin, cmax) {
+        let t = Math.min(1, Math.max(0, (val - cmin) / (cmax - cmin)));
+        const tc = isMSL ? 1 - t : t;
+        for (let i = 0; i < TURBO_SCALE.length - 1; i++) {
+          if (tc >= TURBO_SCALE[i][0] && tc <= TURBO_SCALE[i + 1][0]) {
+            const ratio =
+              (tc - TURBO_SCALE[i][0]) /
+              (TURBO_SCALE[i + 1][0] - TURBO_SCALE[i][0]);
+            const r = Math.round(
+              TURBO_SCALE[i][1][0] +
+                (TURBO_SCALE[i + 1][1][0] - TURBO_SCALE[i][1][0]) * ratio,
+            );
+            const g = Math.round(
+              TURBO_SCALE[i][1][1] +
+                (TURBO_SCALE[i + 1][1][1] - TURBO_SCALE[i][1][1]) * ratio,
+            );
+            const b = Math.round(
+              TURBO_SCALE[i][1][2] +
+                (TURBO_SCALE[i + 1][1][2] - TURBO_SCALE[i][1][2]) * ratio,
+            );
             return `rgb(${r}, ${g}, ${b})`;
+          }
         }
-    }
-    return `rgb(0,0,0)`;
-}
+        return `rgb(0,0,0)`;
+      }
 
-async function init() {
-    if (window.TRACKS_DATA) {
-        allData = window.TRACKS_DATA;
-        const meta = allData.metadata;
-        const isMSL = meta.track_type === 'msl';
-        const unit = isMSL ? "hPa" : "10⁻⁵ s⁻¹";
-        
-        const ptCount = allData.points.lat.length;
-        masterLats = new Float32Array(allData.points.lat);
-        masterLons = new Float32Array(allData.points.lon);
-        masterTimes = new Float64Array(allData.points.time);
-        masterStrengths = new Float32Array(allData.points.strength);
-        masterHoverTexts = new Array(ptCount);
-        
-        // 1. Pre-calculate track static texts ONCE to save massive CPU/GC overhead during animation
-        allData.tracks.forEach(t => {
+      async function init() {
+        if (window.TRACKS_DATA) {
+          allData = window.TRACKS_DATA;
+          const meta = allData.metadata;
+          const isMSL = meta.track_type === "msl";
+          const unit = isMSL ? "hPa" : "10⁻⁵ s⁻¹";
+
+          const ptCount = allData.points.lat.length;
+          masterLats = new Float32Array(allData.points.lat);
+          masterLons = new Float32Array(allData.points.lon);
+          masterTimes = new Float64Array(allData.points.time);
+          masterStrengths = new Float32Array(allData.points.strength);
+          masterHoverTexts = new Array(ptCount);
+
+          // 1. Pre-calculate track static texts ONCE to save massive CPU/GC overhead during animation
+          allData.tracks.forEach((t) => {
             const startTimeStr = formatTime(masterTimes[t.start]);
             const endTimeStr = formatTime(masterTimes[t.end]);
             const peakText = `Track ID: ${t.track_id}<br>Peak: ${t.strength.toFixed(1)} ${unit}`;
             const durText = `<br>Start: ${startTimeStr}<br>End: ${endTimeStr}<br>Dur: ${t.duration}h`;
-            
-            for(let p = t.start; p <= t.end; p++) {
-                const ptTimeStr = formatTime(masterTimes[p]);
-                masterHoverTexts[p] = `${peakText}<br>Curr: ${masterStrengths[p].toFixed(1)} ${unit}<br>Time: ${ptTimeStr}${durText}`;
+
+            for (let p = t.start; p <= t.end; p++) {
+              const ptTimeStr = formatTime(masterTimes[p]);
+              masterHoverTexts[p] =
+                `${peakText}<br>Curr: ${masterStrengths[p].toFixed(1)} ${unit}<br>Time: ${ptTimeStr}${durText}`;
             }
-        });
+          });
 
-        setupControls();
-        updateLegend();
-        elements.loading.style.display = 'none';
-        document.querySelector('.range-slider').classList.add('not-animating');
-        
-        elements.btnPlayPause.addEventListener('click', () => isPlaying ? pauseAnimation() : playAnimation());
-        elements.btnSpeedDown.addEventListener('click', () => changeSpeed(-1));
-        elements.btnSpeedUp.addEventListener('click', () => changeSpeed(1));
-        elements.btnReset.addEventListener('click', resetAnimation);
-        window.addEventListener('resize', () => { updatePlot(true); updateLegend(); });
-        
-        elements.plot.addEventListener('mousedown', () => { isDraggingMap = true; });
-        elements.plot.addEventListener('touchstart', () => { isDraggingMap = true; }, {passive: true});
-        window.addEventListener('mouseup', () => { isDraggingMap = false; });
-        window.addEventListener('touchend', () => { isDraggingMap = false; }, {passive: true});
+          setupControls();
+          updateLegend();
+          elements.loading.style.display = "none";
+          document
+            .querySelector(".range-slider")
+            .classList.add("not-animating");
 
-        const toggleFps = () => {
+          elements.btnPlayPause.addEventListener("click", () =>
+            isPlaying ? pauseAnimation() : playAnimation(),
+          );
+          elements.btnSpeedDown.addEventListener("click", () =>
+            changeSpeed(-1),
+          );
+          elements.btnSpeedUp.addEventListener("click", () => changeSpeed(1));
+          elements.btnReset.addEventListener("click", resetAnimation);
+          window.addEventListener("resize", () => {
+            updatePlot(true);
+            updateLegend();
+          });
+
+          elements.plot.addEventListener("mousedown", () => {
+            isDraggingMap = true;
+          });
+          elements.plot.addEventListener(
+            "touchstart",
+            () => {
+              isDraggingMap = true;
+            },
+            { passive: true },
+          );
+          window.addEventListener("mouseup", () => {
+            isDraggingMap = false;
+          });
+          window.addEventListener(
+            "touchend",
+            () => {
+              isDraggingMap = false;
+            },
+            { passive: true },
+          );
+
+          const toggleFps = () => {
             const disp = elements.fpsDisplay.style.display;
-            elements.fpsDisplay.style.display = (disp === 'none' || disp === '') ? 'block' : 'none';
-        };
-        elements.fpsToggle.addEventListener('dblclick', toggleFps);
-        
-        let lastTap = 0;
-        elements.fpsToggle.addEventListener('touchstart', (e) => {
-            const now = performance.now();
-            if (now - lastTap < 300) {
+            elements.fpsDisplay.style.display =
+              disp === "none" || disp === "" ? "block" : "none";
+          };
+          elements.fpsToggle.addEventListener("dblclick", toggleFps);
+
+          let lastTap = 0;
+          elements.fpsToggle.addEventListener(
+            "touchstart",
+            (e) => {
+              const now = performance.now();
+              if (now - lastTap < 300) {
                 toggleFps();
                 e.preventDefault();
-            }
-            lastTap = now;
-        }, {passive: false});
+              }
+              lastTap = now;
+            },
+            { passive: false },
+          );
 
-        elements.timeScrub.addEventListener('input', () => {
+          elements.timeScrub.addEventListener("input", () => {
             if (isPlaying) pauseAnimation();
-            document.querySelector('.range-slider').classList.remove('not-animating');
+            document
+              .querySelector(".range-slider")
+              .classList.remove("not-animating");
             currentAnimTime = parseInt(elements.timeScrub.value);
             updateSliderFill();
             updatePlot(); // time scrub is not a structural change
-        });
+          });
 
-        updatePlot(true);
-    } else {
-        elements.status.innerHTML = `<b style='color:red'>Error:</b> Data script not found. If using split mode, ensure the .tracks.js file is present and loaded correctly.`;
-        elements.loading.innerHTML = `<span style='color:red'>Data failed to load.</span>`;
-    }
-}
+          updatePlot(true);
+        } else {
+          elements.status.innerHTML = `<b style='color:red'>Error:</b> Data script not found. If using split mode, ensure the .tracks.js file is present and loaded correctly.`;
+          elements.loading.innerHTML = `<span style='color:red'>Data failed to load.</span>`;
+        }
+      }
 
-function updateFilterCache() {
-    const meta = allData.metadata;
-    const isMSL = meta.track_type === 'msl';
-    const cmin = meta.min_strength;
-    const cmax = meta.max_strength;
-    
-    const strengthThresh = parseFloat(elements.strength.value);
-    const minDur = parseFloat(elements.duration.value);
-    const minDist = parseFloat(elements.displacement.value);
-    
-    activeTrackIndices = [];
-    
-    const bins = Array(11).fill(0).map(() => ({
-        lats: [], lons: [], times: [], texts: [], colors: []
-    }));
+      function updateFilterCache() {
+        const meta = allData.metadata;
+        const isMSL = meta.track_type === "msl";
+        const cmin = meta.min_strength;
+        const cmax = meta.max_strength;
 
-    for (let i = 0; i < allData.tracks.length; i++) {
-        const t = allData.tracks[i];
-        const sMatch = isMSL ? t.strength <= strengthThresh : t.strength >= strengthThresh;
-        if (sMatch && t.duration >= minDur && t.displacement >= minDist) {
+        const strengthThresh = parseFloat(elements.strength.value);
+        const minDur = parseFloat(elements.duration.value);
+        const minDist = parseFloat(elements.displacement.value);
+
+        activeTrackIndices = [];
+
+        const bins = Array(11)
+          .fill(0)
+          .map(() => ({
+            lats: [],
+            lons: [],
+            times: [],
+            texts: [],
+            colors: [],
+          }));
+
+        for (let i = 0; i < allData.tracks.length; i++) {
+          const t = allData.tracks[i];
+          const sMatch = isMSL
+            ? t.strength <= strengthThresh
+            : t.strength >= strengthThresh;
+          if (sMatch && t.duration >= minDur && t.displacement >= minDist) {
             activeTrackIndices.push(i);
-            
+
             let currentBin = -1;
             for (let p = t.start; p <= t.end; p++) {
-                let v = masterStrengths[p];
-                let t_val = Math.min(1, Math.max(0, (v - cmin) / (cmax - cmin)));
-                const tc = isMSL ? (1 - t_val) : t_val;
-                const newBin = Math.min(Math.floor(tc * 10), 10);
-                const ptColor = `rgb(${TURBO_SCALE[newBin][1].join(',')})`;
-                const hText = masterHoverTexts[p];
-                
-                if (currentBin !== -1 && currentBin !== newBin) {
-                    // Bin changed. Close old, start new.
-                    bins[currentBin].lats.push(masterLats[p], NaN);
-                    bins[currentBin].lons.push(masterLons[p], NaN);
-                    bins[currentBin].times.push(masterTimes[p], masterTimes[p]);
-                    bins[currentBin].texts.push(hText, "");
-                    bins[currentBin].colors.push(ptColor, 'rgba(0,0,0,0)');
-                    
-                    bins[newBin].lats.push(masterLats[p]);
-                    bins[newBin].lons.push(masterLons[p]);
-                    bins[newBin].times.push(masterTimes[p]);
-                    bins[newBin].texts.push(hText);
-                    bins[newBin].colors.push(ptColor);
-                } else {
-                    bins[newBin].lats.push(masterLats[p]);
-                    bins[newBin].lons.push(masterLons[p]);
-                    bins[newBin].times.push(masterTimes[p]);
-                    bins[newBin].texts.push(hText);
-                    bins[newBin].colors.push(ptColor);
-                }
-                currentBin = newBin;
+              let v = masterStrengths[p];
+              let t_val = Math.min(1, Math.max(0, (v - cmin) / (cmax - cmin)));
+              const tc = isMSL ? 1 - t_val : t_val;
+              const newBin = Math.min(Math.floor(tc * 10), 10);
+              const ptColor = `rgb(${TURBO_SCALE[newBin][1].join(",")})`;
+              const hText = masterHoverTexts[p];
+
+              if (currentBin !== -1 && currentBin !== newBin) {
+                // Bin changed. Close old, start new.
+                bins[currentBin].lats.push(masterLats[p], NaN);
+                bins[currentBin].lons.push(masterLons[p], NaN);
+                bins[currentBin].times.push(masterTimes[p], masterTimes[p]);
+                bins[currentBin].texts.push(hText, "");
+                bins[currentBin].colors.push(ptColor, "rgba(0,0,0,0)");
+
+                bins[newBin].lats.push(masterLats[p]);
+                bins[newBin].lons.push(masterLons[p]);
+                bins[newBin].times.push(masterTimes[p]);
+                bins[newBin].texts.push(hText);
+                bins[newBin].colors.push(ptColor);
+              } else {
+                bins[newBin].lats.push(masterLats[p]);
+                bins[newBin].lons.push(masterLons[p]);
+                bins[newBin].times.push(masterTimes[p]);
+                bins[newBin].texts.push(hText);
+                bins[newBin].colors.push(ptColor);
+              }
+              currentBin = newBin;
             }
             if (currentBin !== -1) {
-                bins[currentBin].lats.push(NaN);
-                bins[currentBin].lons.push(NaN);
-                bins[currentBin].times.push(masterTimes[t.end]);
-                bins[currentBin].texts.push("");
-                bins[currentBin].colors.push('rgba(0,0,0,0)');
+              bins[currentBin].lats.push(NaN);
+              bins[currentBin].lons.push(NaN);
+              bins[currentBin].times.push(masterTimes[t.end]);
+              bins[currentBin].texts.push("");
+              bins[currentBin].colors.push("rgba(0,0,0,0)");
             }
+          }
         }
-    }
-    
-    // Compile to TypedArrays for ultra-fast masking during animation
-    bins.forEach(b => {
-        b.f32Lats = new Float32Array(b.lats);
-        b.f32Lons = new Float32Array(b.lons);
-        b.f64Times = new Float64Array(b.times);
-        b.workingLats = new Float32Array(b.lats.length);
-        b.workingLons = new Float32Array(b.lons.length);
-    });
-    
-    renderCache.bins = bins;
-    renderCache.built = true;
-}
 
-function updateLegend() {
-    const meta = allData.metadata;
-    const isMSL = meta.track_type === 'msl';
-    elements.legendUnit.innerText = isMSL ? "hPa" : "10⁻⁵ s⁻¹";
-    
-    const cmin = meta.min_strength;
-    const cmax = meta.max_strength;
-    
-    if (isMSL) {
-        elements.legendBar.style.background = "linear-gradient(to bottom, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1))";
-        elements.legendLabels.innerHTML = `<span>${cmax.toFixed(0)}</span><span>${((cmin+cmax)/2).toFixed(0)}</span><span>${cmin.toFixed(0)}</span>`;
-    } else {
-        elements.legendBar.style.background = "linear-gradient(to top, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1))";
-        elements.legendLabels.innerHTML = `<span>${cmax.toFixed(1)}</span><span>${((cmin+cmax)/2).toFixed(1)}</span><span>${cmin.toFixed(1)}</span>`;
-    }
-}
+        // Compile to TypedArrays for ultra-fast masking during animation
+        bins.forEach((b) => {
+          b.f32Lats = new Float32Array(b.lats);
+          b.f32Lons = new Float32Array(b.lons);
+          b.f64Times = new Float64Array(b.times);
+          b.workingLats = new Float32Array(b.lats.length);
+          b.workingLons = new Float32Array(b.lons.length);
+        });
 
-function changeSpeed(delta) {
-    speedIdx = Math.max(0, Math.min(SPEEDS.length - 1, speedIdx + delta));
-    elements.speedVal.innerText = SPEEDS[speedIdx] + 'x';
-}
+        renderCache.bins = bins;
+        renderCache.built = true;
+      }
 
-function updateSliderFill() {
-    [elements.duration, elements.displacement].forEach(el => {
-        const val = (el.value - el.min) / (el.max - el.min) * 100;
-        el.style.background = `linear-gradient(to right, #007bff ${val}%, #ddd ${val}%)`;
-    });
-    
-    // Peak Strength fills from right (Minimum Intensity)
-    const sVal = (elements.strength.value - elements.strength.min) / (elements.strength.max - elements.strength.min) * 100;
-    elements.strength.style.background = `linear-gradient(to left, #007bff ${100 - sVal}%, #ddd ${100 - sVal}%)`;
+      function updateLegend() {
+        const meta = allData.metadata;
+        const isMSL = meta.track_type === "msl";
+        elements.legendUnit.innerText = isMSL ? "hPa" : "10⁻⁵ s⁻¹";
 
-    const min = parseInt(elements.timeStart.min);
-    const max = parseInt(elements.timeStart.max);
-    const v1 = parseInt(elements.timeStart.value);
-    const v2 = parseInt(elements.timeEnd.value);
-    const vs = parseInt(elements.timeScrub.value);
-    
-    // Trail calculation for timeline background
-    const tailTime = Math.max(v1, vs - TRAIL_DAYS_MS);
-    
-    const p1 = (v1 - min) / (max - min);
-    const p2 = (v2 - min) / (max - min);
-    const ps = (vs - min) / (max - min);
-    const pt = (tailTime - min) / (max - min);
-    
-    elements.timeTrack.style.setProperty('--p1', p1);
-    elements.timeTrack.style.setProperty('--p2', p2);
-    elements.timeTrack.style.setProperty('--ps', ps);
-    elements.timeTrack.style.setProperty('--pt', pt);
-}
+        const cmin = meta.min_strength;
+        const cmax = meta.max_strength;
 
-function setupControls() {
-    const meta = allData.metadata;
-    const isMSL = meta.track_type === 'msl';
-    
-    [elements.timeStart, elements.timeEnd, elements.timeScrub].forEach(el => {
-        el.min = meta.min_time;
-        el.max = meta.max_time;
-    });
-    
-    elements.timeStart.value = meta.min_time;
-    elements.timeEnd.value = meta.max_time;
-    elements.timeScrub.value = meta.min_time;
-
-    elements.timeStart.addEventListener('input', () => {
-        if (parseInt(elements.timeStart.value) >= parseInt(elements.timeEnd.value)) {
-            elements.timeStart.value = parseInt(elements.timeEnd.value) - HOUR_MS;
+        if (isMSL) {
+          elements.legendBar.style.background =
+            "linear-gradient(to bottom, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1))";
+          elements.legendLabels.innerHTML = `<span>${cmax.toFixed(0)}</span><span>${((cmin + cmax) / 2).toFixed(0)}</span><span>${cmin.toFixed(0)}</span>`;
+        } else {
+          elements.legendBar.style.background =
+            "linear-gradient(to top, rgb(48, 18, 59), rgb(70, 74, 164), rgb(61, 126, 237), rgb(33, 176, 213), rgb(24, 215, 160), rgb(100, 240, 91), rgb(178, 230, 54), rgb(238, 182, 48), rgb(254, 112, 28), rgb(226, 45, 6), rgb(158, 1, 1))";
+          elements.legendLabels.innerHTML = `<span>${cmax.toFixed(1)}</span><span>${((cmin + cmax) / 2).toFixed(1)}</span><span>${cmin.toFixed(1)}</span>`;
         }
-        if (currentAnimTime !== null && parseInt(elements.timeScrub.value) < parseInt(elements.timeStart.value)) {
+      }
+
+      function changeSpeed(delta) {
+        speedIdx = Math.max(0, Math.min(SPEEDS.length - 1, speedIdx + delta));
+        elements.speedVal.innerText = SPEEDS[speedIdx] + "x";
+      }
+
+      function updateSliderFill() {
+        [elements.duration, elements.displacement].forEach((el) => {
+          const val = ((el.value - el.min) / (el.max - el.min)) * 100;
+          el.style.background = `linear-gradient(to right, #007bff ${val}%, #ddd ${val}%)`;
+        });
+
+        // Peak Strength fills from right (Minimum Intensity)
+        const sVal =
+          ((elements.strength.value - elements.strength.min) /
+            (elements.strength.max - elements.strength.min)) *
+          100;
+        elements.strength.style.background = `linear-gradient(to left, #007bff ${100 - sVal}%, #ddd ${100 - sVal}%)`;
+
+        const min = parseInt(elements.timeStart.min);
+        const max = parseInt(elements.timeStart.max);
+        const v1 = parseInt(elements.timeStart.value);
+        const v2 = parseInt(elements.timeEnd.value);
+        const vs = parseInt(elements.timeScrub.value);
+
+        // Trail calculation for timeline background
+        const tailTime = Math.max(v1, vs - TRAIL_DAYS_MS);
+
+        const p1 = (v1 - min) / (max - min);
+        const p2 = (v2 - min) / (max - min);
+        const ps = (vs - min) / (max - min);
+        const pt = (tailTime - min) / (max - min);
+
+        elements.timeTrack.style.setProperty("--p1", p1);
+        elements.timeTrack.style.setProperty("--p2", p2);
+        elements.timeTrack.style.setProperty("--ps", ps);
+        elements.timeTrack.style.setProperty("--pt", pt);
+      }
+
+      function setupControls() {
+        const meta = allData.metadata;
+        const isMSL = meta.track_type === "msl";
+
+        [elements.timeStart, elements.timeEnd, elements.timeScrub].forEach(
+          (el) => {
+            el.min = meta.min_time;
+            el.max = meta.max_time;
+          },
+        );
+
+        elements.timeStart.value = meta.min_time;
+        elements.timeEnd.value = meta.max_time;
+        elements.timeScrub.value = meta.min_time;
+
+        elements.timeStart.addEventListener("input", () => {
+          if (
+            parseInt(elements.timeStart.value) >=
+            parseInt(elements.timeEnd.value)
+          ) {
+            elements.timeStart.value =
+              parseInt(elements.timeEnd.value) - HOUR_MS;
+          }
+          if (
+            currentAnimTime !== null &&
+            parseInt(elements.timeScrub.value) <
+              parseInt(elements.timeStart.value)
+          ) {
             elements.timeScrub.value = elements.timeStart.value;
             currentAnimTime = parseInt(elements.timeScrub.value);
-        }
-    });
-    elements.timeEnd.addEventListener('input', () => {
-        if (parseInt(elements.timeEnd.value) <= parseInt(elements.timeStart.value)) {
-            elements.timeEnd.value = parseInt(elements.timeStart.value) + HOUR_MS;
-        }
-        if (currentAnimTime !== null && parseInt(elements.timeScrub.value) > parseInt(elements.timeEnd.value)) {
+          }
+        });
+        elements.timeEnd.addEventListener("input", () => {
+          if (
+            parseInt(elements.timeEnd.value) <=
+            parseInt(elements.timeStart.value)
+          ) {
+            elements.timeEnd.value =
+              parseInt(elements.timeStart.value) + HOUR_MS;
+          }
+          if (
+            currentAnimTime !== null &&
+            parseInt(elements.timeScrub.value) >
+              parseInt(elements.timeEnd.value)
+          ) {
             elements.timeScrub.value = elements.timeEnd.value;
             currentAnimTime = parseInt(elements.timeScrub.value);
-        }
-    });
-    
-    elements.strengthLabel.innerText = isMSL ? "Peak MSL (hPa)" : "Peak VO (10⁻⁵ s⁻¹)";
-    elements.strength.min = Math.floor(meta.min_strength);
-    elements.strength.max = Math.ceil(meta.max_strength);
-    elements.strength.step = isMSL ? 1 : 0.1;
-    elements.strength.value = isMSL ? Math.max(elements.strength.min, Math.min(elements.strength.max, -15)) : Math.floor(meta.min_strength);
-    elements.strengthMinVal.innerText = elements.strength.min;
-    elements.strengthMaxVal.innerText = elements.strength.max;
-    
-    elements.duration.min = 0;
-    elements.duration.max = Math.ceil(meta.max_duration);
-    elements.duration.value = 48;
-    elements.durationMaxVal.innerText = elements.duration.max + "h";
-    
-    const roundedMaxDisp = Math.ceil(meta.max_displacement / 100) * 100;
-    elements.displacement.min = 100;
-    elements.displacement.max = roundedMaxDisp;
-    elements.displacement.value = Math.min(1000, roundedMaxDisp);
-    elements.displacementMaxVal.innerText = roundedMaxDisp + "km";
-    
-    [elements.projection, elements.timeStart, elements.timeEnd, elements.strength, elements.duration, elements.displacement].forEach(el => {
-        el.addEventListener('input', () => {
-            if (isPlaying && (el === elements.timeStart || el === elements.timeEnd)) {
-                pauseAnimation();
+          }
+        });
+
+        elements.strengthLabel.innerText = isMSL
+          ? "Peak MSL (hPa)"
+          : "Peak VO (10⁻⁵ s⁻¹)";
+        elements.strength.min = Math.floor(meta.min_strength);
+        elements.strength.max = Math.ceil(meta.max_strength);
+        elements.strength.step = isMSL ? 1 : 0.1;
+        elements.strength.value = isMSL
+          ? Math.max(
+              elements.strength.min,
+              Math.min(elements.strength.max, -15),
+            )
+          : Math.floor(meta.min_strength);
+        elements.strengthMinVal.innerText = elements.strength.min;
+        elements.strengthMaxVal.innerText = elements.strength.max;
+
+        elements.duration.min = 0;
+        elements.duration.max = Math.ceil(meta.max_duration);
+        elements.duration.value = 48;
+        elements.durationMaxVal.innerText = elements.duration.max + "h";
+
+        const roundedMaxDisp = Math.ceil(meta.max_displacement / 100) * 100;
+        elements.displacement.min = 100;
+        elements.displacement.max = roundedMaxDisp;
+        elements.displacement.value = Math.min(1000, roundedMaxDisp);
+        elements.displacementMaxVal.innerText = roundedMaxDisp + "km";
+
+        [
+          elements.projection,
+          elements.timeStart,
+          elements.timeEnd,
+          elements.strength,
+          elements.duration,
+          elements.displacement,
+        ].forEach((el) => {
+          el.addEventListener("input", () => {
+            if (
+              isPlaying &&
+              (el === elements.timeStart || el === elements.timeEnd)
+            ) {
+              pauseAnimation();
             } else if (el !== elements.timeStart && el !== elements.timeEnd) {
-                if (isPlaying) pauseAnimation();
+              if (isPlaying) pauseAnimation();
             }
-            if (el === elements.projection || el === elements.strength || el === elements.duration || el === elements.displacement) {
-                updatePlot(true); // force structural rebuild
+            if (
+              el === elements.projection ||
+              el === elements.strength ||
+              el === elements.duration ||
+              el === elements.displacement
+            ) {
+              updatePlot(true); // force structural rebuild
             } else {
-                updatePlot(false);
+              updatePlot(false);
             }
             updateSliderFill();
+          });
         });
-    });
-    updateSliderFill();
-}
+        updateSliderFill();
+      }
 
-function animate(timestamp) {
-    if (!isPlaying) return;
-    
-    if (!lastFrameTime) lastFrameTime = timestamp;
-    const dt = timestamp - lastFrameTime;
-    
-    const targetStepsPerSec = BASE_STEPS_PER_SEC * SPEEDS[speedIdx];
-    const msPerStep = 1000 / targetStepsPerSec;
-    
-    if (dt >= msPerStep) {
-        const tStart = parseInt(elements.timeStart.value);
-        const tEnd = parseInt(elements.timeEnd.value);
-        
-        if (currentAnimTime === null) currentAnimTime = tStart;
+      function animate(timestamp) {
+        if (!isPlaying) return;
 
-        if (!isDraggingMap) {
+        if (!lastFrameTime) lastFrameTime = timestamp;
+        const dt = timestamp - lastFrameTime;
+
+        const targetStepsPerSec = BASE_STEPS_PER_SEC * SPEEDS[speedIdx];
+        const msPerStep = 1000 / targetStepsPerSec;
+
+        if (dt >= msPerStep) {
+          const tStart = parseInt(elements.timeStart.value);
+          const tEnd = parseInt(elements.timeEnd.value);
+
+          if (currentAnimTime === null) currentAnimTime = tStart;
+
+          if (!isDraggingMap) {
             const stepsToAdvance = Math.floor(dt / msPerStep);
             let nextTime = currentAnimTime;
-            
+
             for (let i = 0; i < stepsToAdvance; i++) {
-                if (nextTime >= tEnd) {
-                    if (elements.chkLoop.checked) {
-                        nextTime = tStart;
-                    } else {
-                        nextTime = tEnd;
-                        pauseAnimation();
-                        break;
-                    }
+              if (nextTime >= tEnd) {
+                if (elements.chkLoop.checked) {
+                  nextTime = tStart;
                 } else {
-                    nextTime = Math.min(tEnd, nextTime + HOUR_MS);
+                  nextTime = tEnd;
+                  pauseAnimation();
+                  break;
                 }
+              } else {
+                nextTime = Math.min(tEnd, nextTime + HOUR_MS);
+              }
             }
-            
+
             currentAnimTime = nextTime;
             elements.timeScrub.value = currentAnimTime;
             updateSliderFill();
             updatePlot();
+          }
+
+          lastFrameTime = timestamp - (dt % msPerStep);
         }
-        
-        lastFrameTime = timestamp - (dt % msPerStep);
-    }
-    
-    if (isPlaying) {
+
+        if (isPlaying) {
+          requestAnimationFrame(animate);
+        }
+      }
+
+      function playAnimation() {
+        if (isPlaying) return;
+        isPlaying = true;
+        elements.btnPlayPause.innerText = "Pause";
+        document
+          .querySelector(".range-slider")
+          .classList.remove("not-animating");
+
+        const tStart = parseInt(elements.timeStart.value);
+        const tEnd = parseInt(elements.timeEnd.value);
+        if (currentAnimTime === null || currentAnimTime >= tEnd)
+          currentAnimTime = tStart;
+
+        lastFrameTime = 0;
         requestAnimationFrame(animate);
-    }
-}
+      }
 
-function playAnimation() {
-    if (isPlaying) return;
-    isPlaying = true;
-    elements.btnPlayPause.innerText = 'Pause';
-    document.querySelector('.range-slider').classList.remove('not-animating');
-    
-    const tStart = parseInt(elements.timeStart.value);
-    const tEnd = parseInt(elements.timeEnd.value);
-    if (currentAnimTime === null || currentAnimTime >= tEnd) currentAnimTime = tStart;
-    
-    lastFrameTime = 0;
-    requestAnimationFrame(animate);
-}
+      function pauseAnimation() {
+        isPlaying = false;
+        elements.btnPlayPause.innerText = "Play";
+        updatePlot();
+      }
 
-function pauseAnimation() {
-    isPlaying = false;
-    elements.btnPlayPause.innerText = 'Play';
-    updatePlot();
-}
+      function resetAnimation() {
+        pauseAnimation();
+        currentAnimTime = null;
+        speedIdx = 2;
+        elements.speedVal.innerText = "1x";
+        elements.timeScrub.value = elements.timeStart.value;
+        document.querySelector(".range-slider").classList.add("not-animating");
+        updateSliderFill();
+        updatePlot(true);
+      }
 
-function resetAnimation() { 
-    pauseAnimation(); 
-    currentAnimTime = null; 
-    speedIdx = 2; 
-    elements.speedVal.innerText = '1x';
-    elements.timeScrub.value = elements.timeStart.value;
-    document.querySelector('.range-slider').classList.add('not-animating');
-    updateSliderFill();
-    updatePlot(true); 
-}
+      function updatePlot(forceStructural = false) {
+        if (isUpdating && !forceStructural) return;
+        isUpdating = true;
 
-function updatePlot(forceStructural = false) {
-    if (isUpdating && !forceStructural) return;
-    isUpdating = true;
-    
-    frameCount++;
-    const now = performance.now();
-    if (now - lastFpsUpdate >= 1000) {
-        elements.fpsDisplay.innerText = "FPS: " + frameCount;
-        frameCount = 0;
-        lastFpsUpdate = now;
-    }
+        frameCount++;
+        const now = performance.now();
+        if (now - lastFpsUpdate >= 1000) {
+          elements.fpsDisplay.innerText = "FPS: " + frameCount;
+          frameCount = 0;
+          lastFpsUpdate = now;
+        }
 
-    if (forceStructural || !renderCache.built) {
-        updateFilterCache();
-    }
+        if (forceStructural || !renderCache.built) {
+          updateFilterCache();
+        }
 
-    const meta = allData.metadata;
-    const isMSL = meta.track_type === 'msl';
-    const cmin = meta.min_strength;
-    const cmax = meta.max_strength;
-    
-    const tStart = parseInt(elements.timeStart.value);
-    const tEnd = parseInt(elements.timeEnd.value);
-    const proj = elements.projection.value;
+        const meta = allData.metadata;
+        const isMSL = meta.track_type === "msl";
+        const cmin = meta.min_strength;
+        const cmax = meta.max_strength;
 
-    const isProjChanged = proj !== lastProj || forceStructural;
-    lastProj = proj;
+        const tStart = parseInt(elements.timeStart.value);
+        const tEnd = parseInt(elements.timeEnd.value);
+        const proj = elements.projection.value;
 
-    const winW = window.innerWidth;
-    const isMobile = winW < 600;
-    const isTiny = winW < 400;
-    const plotHeight = proj === 'equirectangular' 
-        ? (isTiny ? 200 : (isMobile ? 250 : 450)) 
-        : (isTiny ? 320 : (isMobile ? 400 : 700));
-    elements.plot.style.height = plotHeight + 'px';
-    document.querySelector('.plot-container').style.height = plotHeight + 'px';
+        const isProjChanged = proj !== lastProj || forceStructural;
+        lastProj = proj;
 
-    elements.timeStartVal.innerText = formatTime(tStart);
-    elements.timeEndVal.innerText = formatTime(tEnd);
+        const winW = window.innerWidth;
+        const isMobile = winW < 600;
+        const isTiny = winW < 400;
+        const plotHeight =
+          proj === "equirectangular"
+            ? isTiny
+              ? 200
+              : isMobile
+                ? 250
+                : 450
+            : isTiny
+              ? 320
+              : isMobile
+                ? 400
+                : 700;
+        elements.plot.style.height = plotHeight + "px";
+        document.querySelector(".plot-container").style.height =
+          plotHeight + "px";
 
-    const restyleLat = [];
-    const restyleLon = [];
-    const limitTime = currentAnimTime !== null ? currentAnimTime : tEnd;
-    const tailTime = currentAnimTime !== null ? Math.max(tStart, currentAnimTime - TRAIL_DAYS_MS) : tStart;
+        elements.timeStartVal.innerText = formatTime(tStart);
+        elements.timeEndVal.innerText = formatTime(tEnd);
 
-    // 1. Zero-Allocation TypedArray Masking
-    for (let i = 0; i < 11; i++) {
-        const bin = renderCache.bins[i];
-        const viewLats = bin.workingLats;
-        const viewLons = bin.workingLons;
-        
-        // Instant C-level memory copy instead of GC allocation
-        viewLats.set(bin.f32Lats);
-        viewLons.set(bin.f32Lons);
-        
-        const times = bin.f64Times;
-        const len = times.length;
-        
-        for (let j = 0; j < len; j++) {
+        const restyleLat = [];
+        const restyleLon = [];
+        const limitTime = currentAnimTime !== null ? currentAnimTime : tEnd;
+        const tailTime =
+          currentAnimTime !== null
+            ? Math.max(tStart, currentAnimTime - TRAIL_DAYS_MS)
+            : tStart;
+
+        // 1. Zero-Allocation TypedArray Masking
+        for (let i = 0; i < 11; i++) {
+          const bin = renderCache.bins[i];
+          const viewLats = bin.workingLats;
+          const viewLons = bin.workingLons;
+
+          // Instant C-level memory copy instead of GC allocation
+          viewLats.set(bin.f32Lats);
+          viewLons.set(bin.f32Lons);
+
+          const times = bin.f64Times;
+          const len = times.length;
+
+          for (let j = 0; j < len; j++) {
             const t = times[j];
             if (t > limitTime || t < tailTime) {
-                viewLats[j] = NaN;
-                viewLons[j] = NaN;
+              viewLats[j] = NaN;
+              viewLons[j] = NaN;
             }
+          }
+          restyleLat.push(viewLats);
+          restyleLon.push(viewLons);
         }
-        restyleLat.push(viewLats);
-        restyleLon.push(viewLons);
-    }
 
-    // 2. Compute Active Heads
-    const curLats = [], curLons = [], curColors = [], curTexts = [];
-    
-    if (currentAnimTime !== null) {
-        for (let i = 0; i < activeTrackIndices.length; i++) {
+        // 2. Compute Active Heads
+        const curLats = [],
+          curLons = [],
+          curColors = [],
+          curTexts = [];
+
+        if (currentAnimTime !== null) {
+          for (let i = 0; i < activeTrackIndices.length; i++) {
             const t = allData.tracks[activeTrackIndices[i]];
-            if (masterTimes[t.start] <= limitTime && masterTimes[t.end] >= limitTime) {
-                let headIdx = -1;
-                // Fast reverse scan (O(1) amortized since limitTime is usually near the end)
-                for (let p = t.end; p >= t.start; p--) {
-                    if (masterTimes[p] <= limitTime) {
-                        headIdx = p;
-                        break;
-                    }
+            if (
+              masterTimes[t.start] <= limitTime &&
+              masterTimes[t.end] >= limitTime
+            ) {
+              let headIdx = -1;
+              // Fast reverse scan (O(1) amortized since limitTime is usually near the end)
+              for (let p = t.end; p >= t.start; p--) {
+                if (masterTimes[p] <= limitTime) {
+                  headIdx = p;
+                  break;
                 }
-                if (headIdx !== -1 && masterTimes[headIdx] >= tailTime) {
-                    curLats.push(masterLats[headIdx]);
-                    curLons.push(masterLons[headIdx]);
-                    curColors.push(getColor(masterStrengths[headIdx], isMSL, cmin, cmax));
-                    curTexts.push(masterHoverTexts[headIdx]);
-                }
+              }
+              if (headIdx !== -1 && masterTimes[headIdx] >= tailTime) {
+                curLats.push(masterLats[headIdx]);
+                curLons.push(masterLons[headIdx]);
+                curColors.push(
+                  getColor(masterStrengths[headIdx], isMSL, cmin, cmax),
+                );
+                curTexts.push(masterHoverTexts[headIdx]);
+              }
             }
+          }
         }
-    }
-    restyleLat.push(curLats);
-    restyleLon.push(curLons);
+        restyleLat.push(curLats);
+        restyleLon.push(curLons);
 
-    elements.status.innerText = (isPlaying || currentAnimTime !== null) ? `Animating: ${formatTime(currentAnimTime)}` : `Showing ${activeTrackIndices.length} tracks`;
-    elements.status.style.color = (isPlaying || currentAnimTime !== null) ? "#dc3545" : "#666";
+        elements.status.innerText =
+          isPlaying || currentAnimTime !== null
+            ? `Animating: ${formatTime(currentAnimTime)}`
+            : `Showing ${activeTrackIndices.length} tracks`;
+        elements.status.style.color =
+          isPlaying || currentAnimTime !== null ? "#dc3545" : "#666";
 
-    // 3. Render
-    if (forceStructural || !tracesInitialized) {
-        tracesInitialized = true;
-        const traces = [];
-        
-        TURBO_SCALE.forEach((bin, idx) => {
-            const color = `rgb(${bin[1].join(',')})`;
+        // 3. Render
+        if (forceStructural || !tracesInitialized) {
+          tracesInitialized = true;
+          const traces = [];
+
+          TURBO_SCALE.forEach((bin, idx) => {
+            const color = `rgb(${bin[1].join(",")})`;
             traces.push({
-                type: 'scattergeo', mode: 'lines+markers', lat: restyleLat[idx], lon: restyleLon[idx],
-                line: { color: color, width: 1.5 },
-                marker: { size: 1, color: 'rgba(0,0,0,0)', line: {width: 0} }, 
-                hovertext: renderCache.bins[idx].texts,
-                hovertemplate: '%{hovertext}<extra></extra>',
-                hoverlabel: { bgcolor: renderCache.bins[idx].colors, bordercolor: '#fff' },
-                showlegend: false
+              type: "scattergeo",
+              mode: "lines+markers",
+              lat: restyleLat[idx],
+              lon: restyleLon[idx],
+              line: { color: color, width: 1.5 },
+              marker: { size: 1, color: "rgba(0,0,0,0)", line: { width: 0 } },
+              hovertext: renderCache.bins[idx].texts,
+              hovertemplate: "%{hovertext}<extra></extra>",
+              hoverlabel: {
+                bgcolor: renderCache.bins[idx].colors,
+                bordercolor: "#fff",
+              },
+              showlegend: false,
             });
-        });
-        
-        traces.push({ 
-            type: 'scattergeo', mode: 'markers', lat: curLats, lon: curLons, 
-            marker: { size: 10, color: curColors, line: { width: 1.5, color: '#333' } }, 
-            hovertext: curTexts,
-            hovertemplate: '%{hovertext}<extra></extra>',
-            hoverlabel: { bgcolor: curColors, bordercolor: '#fff' },
-            showlegend: false 
-        });
+          });
 
-        const layout = {
-            margin: { l: 20, r: 20, t: 20, b: 20 }, height: plotHeight,
-            geo: { 
-                showcoastlines: true, coastlinecolor: "#444", showland: true, landcolor: "#eee", showocean: true, oceancolor: "#fff", 
-                projection: { type: proj }
+          traces.push({
+            type: "scattergeo",
+            mode: "markers",
+            lat: curLats,
+            lon: curLons,
+            marker: {
+              size: 10,
+              color: curColors,
+              line: { width: 1.5, color: "#333" },
             },
-            hovermode: 'closest',
-            uirevision: proj
-        };
-        if (proj === 'orthographic') layout.geo.projection.rotation = { lon: -60, lat: 35 };
+            hovertext: curTexts,
+            hovertemplate: "%{hovertext}<extra></extra>",
+            hoverlabel: { bgcolor: curColors, bordercolor: "#fff" },
+            showlegend: false,
+          });
 
-        Plotly.react(elements.plot, traces, layout, {responsive: true, displayModeBar: false}).then(() => { isUpdating = false; });
-    } else {
-        // High-Performance Temporal Update
-        // Only pass lat/lon for the 11 bins. 
-        // We do not pass text/colors because they never change structure, we just mask the points via lat/lon.
-        const update = {
-            lat: restyleLat,
-            lon: restyleLon
-        };
-        
-        Plotly.restyle(elements.plot, update, Array.from(Array(12).keys())).then(() => {
-            // For the 12th trace (active markers), we must pass text/colors because its array dynamically resizes.
-            const dynamicUpdate = {
-                hovertext: [curTexts],
-                'marker.color': [curColors],
-                'hoverlabel.bgcolor': [curColors]
-            };
-            return Plotly.restyle(elements.plot, dynamicUpdate, [11]);
-        }).then(() => {
+          const layout = {
+            margin: { l: 20, r: 20, t: 20, b: 20 },
+            height: plotHeight,
+            geo: {
+              showcoastlines: true,
+              coastlinecolor: "#444",
+              showland: true,
+              landcolor: "#eee",
+              showocean: true,
+              oceancolor: "#fff",
+              projection: { type: proj },
+            },
+            hovermode: "closest",
+            uirevision: proj,
+          };
+          if (proj === "orthographic")
+            layout.geo.projection.rotation = { lon: -60, lat: 35 };
+
+          Plotly.react(elements.plot, traces, layout, {
+            responsive: true,
+            displayModeBar: false,
+          }).then(() => {
             isUpdating = false;
-        });
-    }
-}
+          });
+        } else {
+          // High-Performance Temporal Update
+          // Only pass lat/lon for the 11 bins.
+          // We do not pass text/colors because they never change structure, we just mask the points via lat/lon.
+          const update = {
+            lat: restyleLat,
+            lon: restyleLon,
+          };
 
-init();
-</script>
-</body>
+          Plotly.restyle(elements.plot, update, Array.from(Array(12).keys()))
+            .then(() => {
+              // For the 12th trace (active markers), we must pass text/colors because its array dynamically resizes.
+              const dynamicUpdate = {
+                hovertext: [curTexts],
+                "marker.color": [curColors],
+                "hoverlabel.bgcolor": [curColors],
+              };
+              return Plotly.restyle(elements.plot, dynamicUpdate, [11]);
+            })
+            .then(() => {
+              isUpdating = false;
+            });
+        }
+      }
+
+      init();
+    </script>
+  </body>
 </html>

--- a/src/pystormtracker/templates/explorer.html
+++ b/src/pystormtracker/templates/explorer.html
@@ -459,10 +459,15 @@ function changeSpeed(delta) {
 }
 
 function updateSliderFill() {
-    [elements.strength, elements.duration, elements.displacement].forEach(el => {
+    [elements.duration, elements.displacement].forEach(el => {
         const val = (el.value - el.min) / (el.max - el.min) * 100;
         el.style.background = `linear-gradient(to right, #007bff ${val}%, #ddd ${val}%)`;
     });
+    
+    // Peak Strength fills from right (Minimum Intensity)
+    const sVal = (elements.strength.value - elements.strength.min) / (elements.strength.max - elements.strength.min) * 100;
+    elements.strength.style.background = `linear-gradient(to left, #007bff ${100 - sVal}%, #ddd ${100 - sVal}%)`;
+
     const min = parseInt(elements.timeStart.min);
     const max = parseInt(elements.timeStart.max);
     const v1 = parseInt(elements.timeStart.value);
@@ -541,7 +546,7 @@ function setupControls() {
             } else if (el !== elements.timeStart && el !== elements.timeEnd) {
                 if (isPlaying) pauseAnimation();
             }
-            if (el === elements.strength || el === elements.duration || el === elements.displacement) {
+            if (el === elements.projection || el === elements.strength || el === elements.duration || el === elements.displacement) {
                 updatePlot(true); // force structural rebuild
             } else {
                 updatePlot(false);


### PR DESCRIPTION
## Overview
This PR fixes two bugs in the Interactive Storm Track Explorer:
- **Projection Switching**: Fixed a bug where switching between Globe (3D) and Global (Lat/Lon) projections would not trigger a structural re-render.
- **Strength Filter UI**: Adjusted the "Peak Strength" slider to fill from the right. This provides a more intuitive visual representation when filtering for minimum intensity (e.g., MSL pressure minima).

### Key Changes
- Updated `src/pystormtracker/templates/explorer.html` event listeners to force structural updates on projection changes.
- Modified slider background CSS in `updateSliderFill()` to support right-to-left filling for the strength parameter.
- Regenerated `docs/_static/explorer.html` using `pst-convert` to propagate these fixes to the documentation.

### Verification
- [x] Verified map projection switching.
- [x] Verified slider visual feedback.