### PR TITLE
ci: consolidate test and publishing workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,30 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+updates:
+  - package-ecosystem: uv
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
+      time: '04:00'
+      timezone: America/New_York
+    groups:
+      python-minor-and-patch:
+        patterns: ['*']
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: '04:15'
+      timezone: America/New_York
+    groups:
+      github-actions:
+        patterns: ['*']
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+      time: '04:30'
+      timezone: America/New_York

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
           if-no-files-found: error
 
   docs:
-    name: Documentation build
+    name: Build documentation
     runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
@@ -300,7 +300,7 @@ jobs:
           fail-on-severity: high
 
   docker-pr:
-    name: Docker build and tests (PR)
+    name: Build and test Docker image
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-26.04
     timeout-minutes: 50
@@ -342,7 +342,7 @@ jobs:
           severity: CRITICAL
 
   docker-staging:
-    name: Docker staging images
+    name: BuildDocker staging images
     if: github.event_name != 'pull_request'
     needs:
       [code-quality, unit-tests, integration-tests, package-tests, docs]
@@ -406,7 +406,7 @@ jobs:
           severity: CRITICAL
 
   docker-staging-manifest:
-    name: Docker staging manifest validation
+    name: ValidateDocker staging manifest
     if: github.event_name != 'pull_request'
     needs: docker-staging
     runs-on: ubuntu-26.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,55 @@ permissions:
   contents: read
 
 env:
-  UV_VERSION: '0.12.0'
+  UV_VERSION: '0.12.1'
 
 jobs:
+  release_context:
+    name: Validate release context
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 10
+    outputs:
+      python_repository: ${{ steps.release.outputs.python_repository }}
+      version: ${{ steps.release.outputs.version }}
+      docker_target: ${{ steps.release.outputs.docker_target }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag is reachable from main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Validate release tag and package version
+        id: release
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+          PACKAGE_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml)"
+          test "$PACKAGE_VERSION" = "$VERSION"
+
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "python_repository=pypi" >> "$GITHUB_OUTPUT"
+            echo "docker_target=release" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$ ]]; then
+            echo "python_repository=testpypi" >> "$GITHUB_OUTPUT"
+            echo "docker_target=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unsupported version tag: $TAG" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
   code-quality:
-    name: code quality checks
+    name: Code quality checks
     runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
@@ -54,8 +98,9 @@ jobs:
       - name: Mypy
         run: uv run --no-sync mypy .
 
-  unit-tests:
-    name: unit (Python ${{ matrix.python-version }}${{ matrix.mode == 'min-deps' && ', min-deps' || '' }})
+  unit-tests-full:
+    name: Unit tests (Python ${{ matrix.python-version }}${{ matrix.mode == 'min-deps' && ', min-deps' || '' }})
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-26.04
     timeout-minutes: 40
     strategy:
@@ -127,8 +172,40 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  integration-tests:
-    name: integration (${{ matrix.os }})
+  unit-tests-pr:
+    name: Unit tests (Python 3.13)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run unit tests with coverage
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v7.0.0
+        with:
+          files: ./coverage.xml
+          disable_search: true
+          flags: unit
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  integration-tests-full:
+    name: Integration tests (${{ matrix.os }})
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 70
     strategy:
@@ -183,8 +260,30 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  integration-tests-pr:
+    name: Integration tests (Ubuntu AMD64)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 70
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run integration tests
+        run: uv run --no-sync pytest -vv tests/integration/ --run-integration
+
   package-tests:
-    name: build and pip-install package
+    name: Package tests (build and installation)
     runs-on: ubuntu-26.04
     timeout-minutes: 25
     steps:
@@ -225,8 +324,16 @@ jobs:
         if: github.event_name != 'pull_request'
         run: .sdist-venv/bin/python -c 'import pystormtracker; print("sdist import success")'
 
+      - name: Upload release distributions
+        if: github.ref_type == 'tag'
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-dists
+          path: dist/
+          if-no-files-found: error
+
   docs:
-    name: documentation build test
+    name: Documentation build
     runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
@@ -244,7 +351,7 @@ jobs:
         run: uv run --no-dev --group docs sphinx-build -b html docs docs/_build/html
 
   dependency-review:
-    name: dependency review
+    name: Dependency review
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-26.04
     timeout-minutes: 10
@@ -258,7 +365,7 @@ jobs:
           fail-on-severity: high
 
   docker-pr:
-    name: D8ocker PR build and test
+    name: Docker build and tests (PR)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-26.04
     timeout-minutes: 50
@@ -300,9 +407,10 @@ jobs:
           severity: CRITICAL
 
   docker-staging:
-    name: Docker staging (${{ matrix.arch }})
+    name: Docker staging image (${{ matrix.arch }})
     if: github.event_name != 'pull_request'
-    needs: [code-quality, unit-tests, integration-tests, package-tests, docs]
+    needs:
+      [code-quality, unit-tests-full, integration-tests-full, package-tests, docs]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 70
     strategy:
@@ -363,7 +471,7 @@ jobs:
           severity: CRITICAL
 
   docker-staging-manifest:
-    name: Docker staging manifest
+    name: Docker staging manifest validation
     if: github.event_name != 'pull_request'
     needs: docker-staging
     runs-on: ubuntu-26.04
@@ -386,9 +494,9 @@ jobs:
       - name: Inspect tested multi-platform staging image
         run: docker buildx imagetools inspect "$STAGING_IMAGE:$STAGING_PREFIX"
 
-  publish-docker-staging:
-    name: publish staging Docker image
-    if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+  publish-docker-edge:
+    name: Publish Docker edge image
+    if: github.ref == 'refs/heads/main'
     needs: docker-staging-manifest
     permissions:
       contents: read
@@ -399,6 +507,41 @@ jobs:
     with:
       source_tag: ci-${{ github.run_id }}-${{ github.run_attempt }}
       source_sha: ${{ github.sha }}
-      channel: ${{ github.ref == 'refs/heads/main' && 'edge' || 'release' }}
-      version: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
-    secrets: inherit
+      target: edge
+    secrets:
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      GHCR_PAT: ${{ secrets.GHCR_PAT }}
+
+  publish-docker-release:
+    name: Publish Docker release image
+    if: github.ref_type == 'tag' && needs.release_context.outputs.docker_target == 'release'
+    needs: [docker-staging-manifest, release_context]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      source_tag: ci-${{ github.run_id }}-${{ github.run_attempt }}
+      source_sha: ${{ github.sha }}
+      target: release
+      version: ${{ needs.release_context.outputs.version }}
+    secrets:
+      DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      GHCR_PAT: ${{ secrets.GHCR_PAT }}
+
+  publish-python:
+    name: Publish Python package
+    if: github.ref_type == 'tag'
+    needs:
+      [release_context, code-quality, unit-tests-full, integration-tests-full, package-tests, docs]
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/python-publish.yml
+    with:
+      artifact_name: release-dists
+      repository: ${{ needs.release_context.outputs.python_repository }}
+      version: ${{ needs.release_context.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,176 +2,161 @@ name: CI
 
 on:
   pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'Dockerfile'
-      - '.github/workflows/ci.yml'
-      - 'docs/**'
-      - 'README.md'
   push:
     branches:
       - main
-      - release/**
-      - 'v*.*'
     tags:
-      - 'v*.*'
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'Dockerfile'
-      - '.github/workflows/ci.yml'
-      - 'docs/**'
-      - 'README.md'
+      - 'v*.*.*'
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 permissions:
   contents: read
 
-jobs:
-  ruff-lint:
-    runs-on: ubuntu-26.04
-    steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/ruff-action@v4.1.0
+env:
+  UV_VERSION: '0.12.0'
 
-  ruff-format:
+jobs:
+  code-quality:
+    name: code quality checks
     runs-on: ubuntu-26.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/ruff-action@v4.1.0
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Ruff lint
+        uses: astral-sh/ruff-action@v4.1.0
+        with:
+          args: check
+          version-file: uv.lock
+
+      - name: Ruff format
+        uses: astral-sh/ruff-action@v4.1.0
         with:
           args: format --check
-
-  mypy-typecheck:
-    runs-on: ubuntu-26.04
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
+          version-file: uv.lock
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
+          python-version: '3.13'
 
-      - name: Install dependencies
+      - name: Install type-checking environment
         run: uv sync --frozen --all-extras
 
-      - name: Type check with Mypy
-        run: uv run --frozen mypy .
+      - name: Mypy
+        run: uv run --no-sync mypy .
 
   unit-tests:
-    name: unit-tests (Python ${{ matrix.python-version }}${{ matrix.min-deps && ', min-deps' || '' }})
+    name: unit (Python ${{ matrix.python-version }}${{ matrix.mode == 'min-deps' && ', min-deps' || '' }})
     runs-on: ubuntu-26.04
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14', '3.14t']
-        min-deps: [false]
         include:
           - python-version: '3.11'
-            min-deps: true
+            mode: normal
+          - python-version: '3.11'
+            mode: min-deps
+          - python-version: '3.12'
+            mode: normal
+          - python-version: '3.13'
+            mode: coverage
+          - python-version: '3.14'
+            mode: normal
           - python-version: '3.14t'
-            free-threaded: true
+            mode: free-threaded
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        if: ${{ !matrix.min-deps && !matrix.free-threaded }}
+        if: matrix.mode == 'normal' || matrix.mode == 'coverage'
         run: uv sync --frozen --all-extras
 
-      - name: Install dependencies (free-threaded)
-        if: matrix.free-threaded
-        run: |
-          uv sync --frozen --extra eof --extra mpi --extra netcdf4  # No grib and zarr support for 3.14 free-threaded
-
-      - name: Install dependencies (min-deps)
-        if: ${{ matrix.min-deps }}
+      - name: Install minimum direct dependencies
+        if: matrix.mode == 'min-deps'
         run: uv sync --all-extras --resolution lowest-direct
 
-      - name: Run Unit Tests
-        if: matrix.python-version != '3.13' && matrix.python-version != '3.14t'
-        run: |
-          uv run --frozen python -VV
-          uv run --frozen pytest -vv
+      - name: Install free-threaded dependencies
+        if: matrix.mode == 'free-threaded'
+        run: uv sync --frozen --extra eof --extra mpi --extra netcdf4
 
-      - name: Run Unit Tests (free-threaded)
-        if: matrix.python-version == '3.14t'
+      - name: Run unit tests
+        if: matrix.mode == 'normal' || matrix.mode == 'min-deps'
+        run: uv run --no-sync pytest -vv
+
+      - name: Run unit tests with coverage
+        if: matrix.mode == 'coverage'
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
+
+      - name: Verify free-threaded Python
+        if: matrix.mode == 'free-threaded'
         env:
           PYTHON_GIL: '0'
-        run: |
-          uv run --frozen python -VV
-          uv run --frozen python -c 'import sys; assert not sys._is_gil_enabled()'
-          uv run --frozen pytest -vv
+        run: uv run --no-sync python -c 'import sys; assert not sys._is_gil_enabled()'
 
-      - name: Run Unit Tests with Coverage
-        if: matrix.python-version == '3.13'
-        run: |
-          uv run --frozen python -VV
-          uv run --frozen pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
+      - name: Run free-threaded unit tests
+        if: matrix.mode == 'free-threaded'
+        env:
+          PYTHON_GIL: '0'
+        run: uv run --no-sync pytest -vv
 
-      - name: Upload coverage reports to Codecov
-        if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v7
+      - name: Upload coverage
+        if: matrix.mode == 'coverage'
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./coverage.xml
+          disable_search: true
           flags: unit
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests:
-    name: integration-tests (${{ matrix.os }})
+    name: integration (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 70
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: amd64
-            os: ubuntu-26.04
-            python-version: '3.13'
-          - arch: arm64
-            os: ubuntu-26.04-arm
-            python-version: '3.13'
-          - arch: amd64
-            os: ubuntu-24.04
-            python-version: '3.13'
-          - arch: arm64
-            os: ubuntu-24.04-arm
-            python-version: '3.13'
-          - arch: amd64
-            os: windows-2025
-            python-version: '3.13'
-          - arch: arm64
-            os: macos-26
-            python-version: '3.13'
+          - os: ubuntu-26.04
+            slow: true
+          - os: ubuntu-26.04-arm
+            slow: false
+          - os: ubuntu-24.04
+            slow: false
+          - os: windows-2025
+            slow: false
+          - os: macos-26
+            slow: false
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.13'
 
-      - name: Install MPI (Windows)
+      - name: Install MPI on Windows
         if: runner.os == 'Windows'
         run: |
           winget install -e --id Microsoft.msmpi --accept-source-agreements --accept-package-agreements
@@ -180,47 +165,146 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras
 
-      - name: Run Integration Tests
-        if: matrix.os != 'ubuntu-26.04' || matrix.arch != 'amd64'
-        run: |
-          uv run --frozen python -VV
-          uv run --frozen pytest -vv tests/integration/ --run-integration
+      - name: Run integration tests
+        if: matrix.slow == false
+        run: uv run --no-sync pytest -vv tests/integration/ --run-integration
 
-      - name: Run Integration Tests with Coverage
-        if: matrix.os == 'ubuntu-26.04' && matrix.arch == 'amd64'
-        run: |
-          uv run --frozen python -VV
-          uv run --frozen pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml tests/integration/ --run-integration --run-slow
+      - name: Run slow integration tests with coverage
+        if: matrix.slow == true
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml tests/integration/ --run-integration --run-slow
 
-      - name: Upload coverage reports to Codecov
-        if: matrix.os == 'ubuntu-26.04' && matrix.arch == 'amd64'
-        uses: codecov/codecov-action@v7
+      - name: Upload coverage
+        if: matrix.slow == true
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./coverage.xml
+          disable_search: true
           flags: integration
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  docs-build:
-    name: docs-build
-    needs: [ruff-lint, ruff-format]
+  package-tests:
+    name: build and pip-install package
     runs-on: ubuntu-26.04
+    timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v9.0.0
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          python-version: '3.13'
+
+      - name: Build wheel and source distribution
+        run: uv build --wheel --sdist
+
+      - name: Create wheel test environment
+        run: uv venv --seed .wheel-venv
+
+      - name: Install wheel using pip
+        run: .wheel-venv/bin/python -m pip install --no-cache-dir dist/*.whl
+
+      - name: Test wheel import
+        run: .wheel-venv/bin/python -c 'import pystormtracker; print("wheel import success")'
+
+      - name: Test wheel CLI
+        run: .wheel-venv/bin/stormtracker --help
+
+      - name: Create source-distribution test environment
+        if: github.event_name != 'pull_request'
+        run: uv venv --seed .sdist-venv
+
+      - name: Install source distribution using pip
+        if: github.event_name != 'pull_request'
+        run: .sdist-venv/bin/python -m pip install --no-cache-dir dist/*.tar.gz
+
+      - name: Test source-distribution import
+        if: github.event_name != 'pull_request'
+        run: .sdist-venv/bin/python -c 'import pystormtracker; print("sdist import success")'
+
+  docs:
+    name: documentation build test
+    runs-on: ubuntu-26.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
           python-version: '3.13'
 
       - name: Build documentation
         run: uv run --no-dev --group docs sphinx-build -b html docs docs/_build/html
 
-  docker-build:
-    name: docker-build (${{ matrix.arch }})
-    needs: [ruff-lint, ruff-format, mypy-typecheck, unit-tests, integration-tests]
+  dependency-review:
+    name: dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/dependency-review-action@v5.0.0
+        with:
+          fail-on-severity: high
+
+  docker-pr:
+    name: D8ocker PR build and test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-26.04
+    timeout-minutes: 50
+    env:
+      IMAGE: local/pystormtracker:${{ github.sha }}-amd64
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Build and load image
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          load: true
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE }}
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=docker-build-linux-amd64
+          cache-to: type=gha,mode=max,scope=docker-build-linux-amd64
+
+      - name: Test container CLI
+        run: docker run --rm "$IMAGE" --help
+
+      - name: Test container import
+        run: docker run --rm --entrypoint python "$IMAGE" -c 'import pystormtracker; print("container import success")'
+
+      - name: Scan critical vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL
+
+  docker-staging:
+    name: Docker staging (${{ matrix.arch }})
+    if: github.event_name != 'pull_request'
+    needs: [code-quality, unit-tests, integration-tests, package-tests, docs]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 70
     strategy:
       fail-fast: false
       matrix:
@@ -229,42 +313,92 @@ jobs:
             os: ubuntu-26.04
           - arch: arm64
             os: ubuntu-26.04-arm
-    runs-on: ${{ matrix.os }}
     env:
-      DOCKER_IMAGE_NAME: '${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}'
+      STAGING_IMAGE: docker.io/${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
+      STAGING_TAG: ci-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@v4.2.0
 
-      - name: Build and load Docker image
-        uses: docker/build-push-action@v7
+      - name: Log in to Docker Hub staging repository
+        uses: docker/login-action@v4.5.1
+        with:
+          username: ${{ vars.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push native image
+        id: build
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
-          push: false
-          load: true
+          push: true
           platforms: linux/${{ matrix.arch }}
-          tags: '${{ env.DOCKER_IMAGE_NAME }}'
-          cache-from: type=gha,scope=docker-build-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=docker-build-${{ matrix.arch }}
+          tags: ${{ env.STAGING_IMAGE }}:${{ env.STAGING_TAG }}
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=docker-build-linux-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-build-linux-${{ matrix.arch }}
 
-      - name: Smoke test Docker image
-        run: |
-          # Test CLI help
-          docker run --rm ${{ env.DOCKER_IMAGE_NAME }} --help
-          # Test library import
-          docker run --rm --entrypoint python ${{ env.DOCKER_IMAGE_NAME }} -c 'import pystormtracker as pst; print("Import success")'
+      - name: Pull exact pushed image
+        run: docker pull "${STAGING_IMAGE}@${{ steps.build.outputs.digest }}"
 
-      - name: Run Trivy vulnerability scanner
+      - name: Test container CLI
+        run: docker run --rm "${STAGING_IMAGE}@${{ steps.build.outputs.digest }}" --help
+
+      - name: Test container import
+        run: docker run --rm --entrypoint python "${STAGING_IMAGE}@${{ steps.build.outputs.digest }}" -c 'import pystormtracker; print("container import success")'
+
+      - name: Scan critical vulnerabilities
+        if: matrix.arch == 'amd64'
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: '${{ env.DOCKER_IMAGE_NAME }}'
-          format: 'table'
-          exit-code: '0'
+          image-ref: ${{ env.STAGING_IMAGE }}@${{ steps.build.outputs.digest }}
+          format: table
+          exit-code: '1'
           ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+          vuln-type: os,library
+          severity: CRITICAL
+
+  docker-staging-manifest:
+    name: Docker staging manifest
+    if: github.event_name != 'pull_request'
+    needs: docker-staging
+    runs-on: ubuntu-26.04
+    timeout-minutes: 15
+    env:
+      STAGING_IMAGE: docker.io/${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
+      STAGING_PREFIX: ci-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Log in to Docker Hub staging repository
+        uses: docker/login-action@v4.5.1
+        with:
+          username: ${{ vars.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Create tested multi-platform staging image
+        run: docker buildx imagetools create --tag "$STAGING_IMAGE:$STAGING_PREFIX" "$STAGING_IMAGE:$STAGING_PREFIX-amd64" "$STAGING_IMAGE:$STAGING_PREFIX-arm64"
+
+      - name: Inspect tested multi-platform staging image
+        run: docker buildx imagetools inspect "$STAGING_IMAGE:$STAGING_PREFIX"
+
+  publish-docker-staging:
+    name: publish staging Docker image
+    if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+    needs: docker-staging-manifest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      source_tag: ci-${{ github.run_id }}-${{ github.run_attempt }}
+      source_sha: ${{ github.sha }}
+      channel: ${{ github.ref == 'refs/heads/main' && 'edge' || 'release' }}
+      version: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       python_repository: ${{ steps.release.outputs.python_repository }}
       version: ${{ steps.release.outputs.version }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
       docker_target: ${{ steps.release.outputs.docker_target }}
     steps:
       - uses: actions/checkout@v7.0.1
@@ -63,6 +64,7 @@ jobs:
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
 
   code-quality:
     name: Code quality checks
@@ -526,7 +528,7 @@ jobs:
       source_tag: ci-${{ github.run_id }}-${{ github.run_attempt }}
       source_sha: ${{ github.sha }}
       target: release
-      version: ${{ needs.release_context.outputs.version }}
+      version: ${{ needs.release_context.outputs.release_tag }}
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       GHCR_PAT: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,53 +18,63 @@ permissions:
 
 env:
   UV_VERSION: '0.12.1'
+  PYTHON_VERSION: '3.13'
 
 jobs:
-  release_context:
-    name: Validate release context
-    if: github.ref_type == 'tag'
+  select-test-matrix:
+    name: Select test matrix
     runs-on: ubuntu-26.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     outputs:
-      python_repository: ${{ steps.release.outputs.python_repository }}
-      version: ${{ steps.release.outputs.version }}
-      release_tag: ${{ steps.release.outputs.release_tag }}
-      docker_target: ${{ steps.release.outputs.docker_target }}
+      unit_matrix: ${{ steps.select.outputs.unit_matrix }}
+      integration_matrix: ${{ steps.select.outputs.integration_matrix }}
     steps:
-      - uses: actions/checkout@v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Verify tag is reachable from main
-        run: |
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
-
-      - name: Validate release tag and package version
-        id: release
-        env:
-          TAG: ${{ github.ref_name }}
+      - name: Select representative or full matrix
+        id: select
         run: |
           set -euo pipefail
 
-          VERSION="${TAG#v}"
-          PACKAGE_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml)"
-          test "$PACKAGE_VERSION" = "$VERSION"
-
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "python_repository=pypi" >> "$GITHUB_OUTPUT"
-            echo "docker_target=release" >> "$GITHUB_OUTPUT"
-          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$ ]]; then
-            echo "python_repository=testpypi" >> "$GITHUB_OUTPUT"
-            echo "docker_target=" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            UNIT_MATRIX='{
+              "include": [
+                {"python-version": "3.13", "mode": "coverage"}
+              ]
+            }'
+            INTEGRATION_MATRIX='{
+              "include": [
+                {"os": "ubuntu-26.04", "slow": false}
+              ]
+            }'
           else
-            echo "Unsupported version tag: $TAG" >&2
-            exit 1
+            UNIT_MATRIX='{
+              "include": [
+                {"python-version": "3.11", "mode": "normal"},
+                {"python-version": "3.11", "mode": "min-deps"},
+                {"python-version": "3.12", "mode": "normal"},
+                {"python-version": "3.13", "mode": "coverage"},
+                {"python-version": "3.14", "mode": "normal"},
+                {"python-version": "3.14t", "mode": "free-threaded"}
+              ]
+            }'
+            INTEGRATION_MATRIX='{
+              "include": [
+                {"os": "ubuntu-26.04", "slow": true},
+                {"os": "ubuntu-26.04-arm", "slow": false},
+                {"os": "ubuntu-24.04", "slow": false},
+                {"os": "windows-2025", "slow": false},
+                {"os": "macos-26", "slow": false}
+              ]
+            }'
           fi
 
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+          {
+            echo "unit_matrix<<EOF"
+            echo "$UNIT_MATRIX"
+            echo "EOF"
+            echo "integration_matrix<<EOF"
+            echo "$INTEGRATION_MATRIX"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
   code-quality:
     name: Code quality checks
@@ -92,7 +102,7 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-          python-version: '3.13'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install type-checking environment
         run: uv sync --frozen --all-extras
@@ -100,27 +110,14 @@ jobs:
       - name: Mypy
         run: uv run --no-sync mypy .
 
-  unit-tests-full:
-    name: Unit tests (Full)
-    if: github.event_name != 'pull_request'
+  unit-tests:
+    name: Unit tests (Python ${{ matrix.python-version }}${{ matrix.mode == 'min-deps' && ', minimum dependencies' || '' }})
+    needs: select-test-matrix
     runs-on: ubuntu-26.04
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - python-version: '3.11'
-            mode: normal
-          - python-version: '3.11'
-            mode: min-deps
-          - python-version: '3.12'
-            mode: normal
-          - python-version: '3.13'
-            mode: coverage
-          - python-version: '3.14'
-            mode: normal
-          - python-version: '3.14t'
-            mode: free-threaded
+      matrix: ${{ fromJSON(needs.select-test-matrix.outputs.unit_matrix) }}
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -174,56 +171,14 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  unit-tests-pr:
-    name: Unit tests (PR)
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-26.04
-    timeout-minutes: 40
-    steps:
-      - uses: actions/checkout@v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: astral-sh/setup-uv@v9.0.0
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: uv sync --frozen --all-extras
-
-      - name: Run unit tests with coverage
-        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v7.0.0
-        with:
-          files: ./coverage.xml
-          disable_search: true
-          flags: unit
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  integration-tests-full:
-    name: Integration tests (Full)
-    if: github.event_name != 'pull_request'
+  integration-tests:
+    name: Integration tests (${{ matrix.os }})
+    needs: select-test-matrix
     runs-on: ${{ matrix.os }}
     timeout-minutes: 70
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-26.04
-            slow: true
-          - os: ubuntu-26.04-arm
-            slow: false
-          - os: ubuntu-24.04
-            slow: false
-          - os: windows-2025
-            slow: false
-          - os: macos-26
-            slow: false
+      matrix: ${{ fromJSON(needs.select-test-matrix.outputs.integration_matrix) }}
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -233,7 +188,7 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-          python-version: '3.13'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install MPI on Windows
         if: runner.os == 'Windows'
@@ -262,30 +217,8 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  integration-tests-pr:
-    name: Integration tests (PR)
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-26.04
-    timeout-minutes: 70
-    steps:
-      - uses: actions/checkout@v7.0.1
-        with:
-          persist-credentials: false
-
-      - uses: astral-sh/setup-uv@v9.0.0
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: uv sync --frozen --all-extras
-
-      - name: Run integration tests
-        run: uv run --no-sync pytest -vv tests/integration/ --run-integration
-
   package-tests:
-    name: Package tests (build and installation)
+    name: Package tests
     runs-on: ubuntu-26.04
     timeout-minutes: 25
     steps:
@@ -297,7 +230,7 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-          python-version: '3.13'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Build wheel and source distribution
         run: uv build --wheel --sdist
@@ -347,7 +280,7 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-          python-version: '3.13'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Build documentation
         run: uv run --no-dev --group docs sphinx-build -b html docs docs/_build/html
@@ -412,7 +345,7 @@ jobs:
     name: Docker staging images
     if: github.event_name != 'pull_request'
     needs:
-      [code-quality, unit-tests-full, integration-tests-full, package-tests, docs]
+      [code-quality, unit-tests, integration-tests, package-tests, docs]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 70
     strategy:
@@ -496,6 +429,53 @@ jobs:
       - name: Inspect tested multi-platform staging image
         run: docker buildx imagetools inspect "$STAGING_IMAGE:$STAGING_PREFIX"
 
+  release_tag:
+    name: Validate release tag
+    if: github.ref_type == 'tag'
+    needs: [code-quality, unit-tests, integration-tests, package-tests, docs]
+    runs-on: ubuntu-26.04
+    timeout-minutes: 10
+    outputs:
+      python_repository: ${{ steps.release.outputs.python_repository }}
+      version: ${{ steps.release.outputs.version }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      docker_target: ${{ steps.release.outputs.docker_target }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag is reachable from main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Validate release tag and package version
+        id: release
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${TAG#v}"
+          PACKAGE_VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml)"
+          test "$PACKAGE_VERSION" = "$VERSION"
+
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "python_repository=pypi" >> "$GITHUB_OUTPUT"
+            echo "docker_target=release" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$ ]]; then
+            echo "python_repository=testpypi" >> "$GITHUB_OUTPUT"
+            echo "docker_target=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unsupported version tag: $TAG" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+
   publish-docker-edge:
     name: Publish Docker edge image
     if: github.ref == 'refs/heads/main'
@@ -516,8 +496,8 @@ jobs:
 
   publish-docker-release:
     name: Publish Docker release image
-    if: github.ref_type == 'tag' && needs.release_context.outputs.docker_target == 'release'
-    needs: [docker-staging-manifest, release_context]
+    if: github.ref_type == 'tag' && needs.release_tag.outputs.docker_target == 'release'
+    needs: [docker-staging-manifest, release_tag]
     permissions:
       contents: read
       packages: write
@@ -528,7 +508,7 @@ jobs:
       source_tag: ci-${{ github.run_id }}-${{ github.run_attempt }}
       source_sha: ${{ github.sha }}
       target: release
-      version: ${{ needs.release_context.outputs.release_tag }}
+      version: ${{ needs.release_tag.outputs.release_tag }}
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
@@ -537,7 +517,7 @@ jobs:
     name: Publish Python package
     if: github.ref_type == 'tag'
     needs:
-      [release_context, code-quality, unit-tests-full, integration-tests-full, package-tests, docs]
+      [release_tag, code-quality, unit-tests, integration-tests, package-tests, docs]
     permissions:
       contents: read
       id-token: write
@@ -545,5 +525,5 @@ jobs:
     uses: ./.github/workflows/python-publish.yml
     with:
       artifact_name: release-dists
-      repository: ${{ needs.release_context.outputs.python_repository }}
-      version: ${{ needs.release_context.outputs.version }}
+      repository: ${{ needs.release_tag.outputs.python_repository }}
+      version: ${{ needs.release_tag.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         run: uv run --no-sync mypy .
 
   unit-tests-full:
-    name: Unit tests (Python ${{ matrix.python-version }}${{ matrix.mode == 'min-deps' && ', min-deps' || '' }})
+    name: Unit tests (Full)
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-26.04
     timeout-minutes: 40
@@ -173,7 +173,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   unit-tests-pr:
-    name: Unit tests (Python 3.13)
+    name: Unit tests (PR)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-26.04
     timeout-minutes: 40
@@ -204,7 +204,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests-full:
-    name: Integration tests (${{ matrix.os }})
+    name: Integration tests (Full)
     if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 70
@@ -261,7 +261,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests-pr:
-    name: Integration tests (Ubuntu AMD64)
+    name: Integration tests (PR)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-26.04
     timeout-minutes: 70
@@ -407,7 +407,7 @@ jobs:
           severity: CRITICAL
 
   docker-staging:
-    name: Docker staging image (${{ matrix.arch }})
+    name: Docker staging images
     if: github.event_name != 'pull_request'
     needs:
       [code-quality, unit-tests-full, integration-tests-full, package-tests, docs]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,8 +11,8 @@ on:
         description: Full commit SHA represented by the staging image
         required: true
         type: string
-      channel:
-        description: Tags to publish
+      target:
+        description: "Promotion target: private, edge, or release"
         required: true
         type: string
       version:
@@ -36,8 +36,8 @@ on:
         description: Full 40-character commit SHA
         required: true
         type: string
-      channel:
-        description: Tags to publish
+      target:
+        description: Promotion target
         required: true
         default: private
         type: choice
@@ -48,7 +48,7 @@ on:
         type: string
 
 concurrency:
-  group: docker-publish-${{ inputs.source_tag }}-${{ inputs.channel }}
+  group: docker-publish-${{ inputs.source_tag }}-${{ inputs.target }}
   cancel-in-progress: false
 
 permissions:
@@ -65,7 +65,8 @@ env:
 
 jobs:
   publish:
-    name: promote tested image
+    name: Promote tested image
+    if: inputs.target == 'private' || inputs.target == 'edge' || inputs.target == 'release'
     runs-on: ubuntu-26.04
     timeout-minutes: 20
     steps:
@@ -93,7 +94,7 @@ jobs:
 
       - name: Resolve release version
         id: release
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         uses: docker/metadata-action@v6.2.0
         with:
           images: ${{ env.PUBLIC_DOCKER_IMAGE }}
@@ -101,18 +102,11 @@ jobs:
 
       - name: Resolve release series
         id: series
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         uses: docker/metadata-action@v6.2.0
         with:
           images: ${{ env.PUBLIC_DOCKER_IMAGE }}
-          tags: type=match,value=${{ inputs.version }},pattern=^v[0-9]+\.[0-9]+\.[0-9]+(?:\.dev[0-9]+)?$,group=1
-
-      - name: Validate commit SHA
-        run: test -n "${{ steps.sha.outputs.version }}"
-
-      - name: Validate stable release tag
-        if: inputs.channel == 'release'
-        run: test -n "${{ steps.release.outputs.version }}"
+          tags: type=match,value=${{ inputs.version }},pattern=^v([0-9]+\.[0-9]+)\.[0-9]+$,group=1
 
       - name: Publish owner SHA tag to Docker Hub
         run: docker buildx imagetools create --tag "${PRIVATE_DOCKER_IMAGE}:${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
@@ -121,44 +115,44 @@ jobs:
         run: docker buildx imagetools create --tag "${PRIVATE_GHCR_IMAGE}:${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
 
       - name: Publish edge to Docker Hub
-        if: inputs.channel == 'edge'
+        if: inputs.target == 'edge'
         run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:edge" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
 
       - name: Publish edge to GHCR
-        if: inputs.channel == 'edge'
+        if: inputs.target == 'edge'
         run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:edge" "${PUBLIC_DOCKER_IMAGE}:edge"
 
       - name: Publish release version to Docker Hub
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ steps.release.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
 
       - name: Publish release series to Docker Hub
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ steps.series.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
 
       - name: Publish latest to Docker Hub
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:latest" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
 
       - name: Publish release version to GHCR
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:${{ steps.release.outputs.version }}" "${PUBLIC_DOCKER_IMAGE}:${{ steps.release.outputs.version }}"
 
       - name: Publish release series to GHCR
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:${{ steps.series.outputs.version }}" "${PUBLIC_DOCKER_IMAGE}:${{ steps.series.outputs.version }}"
 
       - name: Publish latest to GHCR
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:latest" "${PUBLIC_DOCKER_IMAGE}:latest"
 
       - name: Read edge digest
         id: edge-digest
-        if: inputs.channel == 'edge'
+        if: inputs.target == 'edge'
         run: echo "digest=$(docker buildx imagetools inspect "${PUBLIC_DOCKER_IMAGE}:edge" --format '{{.Manifest.Digest}}')" >> "$GITHUB_OUTPUT"
 
       - name: Attest edge on Docker Hub
-        if: inputs.channel == 'edge'
+        if: inputs.target == 'edge'
         uses: actions/attest@v4.2.1
         with:
           subject-name: ${{ env.PUBLIC_DOCKER_IMAGE }}
@@ -167,11 +161,11 @@ jobs:
 
       - name: Read release digest
         id: release-digest
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         run: echo "digest=$(docker buildx imagetools inspect "${PUBLIC_DOCKER_IMAGE}:${{ steps.release.outputs.version }}" --format '{{.Manifest.Digest}}')" >> "$GITHUB_OUTPUT"
 
       - name: Attest release on Docker Hub
-        if: inputs.channel == 'release'
+        if: inputs.target == 'release'
         uses: actions/attest@v4.2.1
         with:
           subject-name: ${{ env.PUBLIC_DOCKER_IMAGE }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,158 +1,179 @@
 name: Docker Publish
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches:
-      - main
-      - 'v*.*'
-      - 'release/**'
+  workflow_call:
+    inputs:
+      source_tag:
+        description: Tested private staging tag
+        required: true
+        type: string
+      source_sha:
+        description: Full commit SHA represented by the staging image
+        required: true
+        type: string
+      channel:
+        description: Tags to publish
+        required: true
+        type: string
+      version:
+        description: Stable release tag such as v0.6.0
+        required: false
+        default: ''
+        type: string
+    secrets:
+      DOCKER_HUB_ACCESS_TOKEN:
+        required: true
+      GHCR_PAT:
+        required: true
+
   workflow_dispatch:
+    inputs:
+      source_tag:
+        description: Tested private staging tag, for example ci-123456789-1
+        required: true
+        type: string
+      source_sha:
+        description: Full 40-character commit SHA
+        required: true
+        type: string
+      channel:
+        description: Tags to publish
+        required: true
+        default: private
+        type: choice
+        options: [private, edge, release]
+      version:
+        description: Stable release tag, required for release publication
+        required: false
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: docker-publish-${{ inputs.source_tag }}-${{ inputs.channel }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  PRIVATE_DOCKER_IMAGE: docker.io/${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
+  PUBLIC_DOCKER_IMAGE: docker.io/${{ vars.DOCKER_ORG_NAME }}/${{ vars.DOCKER_IMAGE_NAME }}
+  PRIVATE_GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
+  PUBLIC_GHCR_IMAGE: ghcr.io/${{ vars.DOCKER_ORG_NAME }}/${{ vars.DOCKER_IMAGE_NAME }}
 
 jobs:
-  build-and-push-platform:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            os: ubuntu-24.04
-          - arch: arm64
-            os: ubuntu-24.04-arm
-    runs-on: ${{ matrix.os }}
-    if: |
-      (github.event_name == 'workflow_run' && 
-       github.event.workflow_run.conclusion == 'success' && 
-       github.event.workflow_run.event != 'pull_request' &&
-       github.event.workflow_run.head_repository.full_name == github.repository) ||
-      github.event_name == 'workflow_dispatch'
-    permissions:
-      contents: read
-      packages: write
-    env:
-      DOCKER_HUB_IMAGE: docker.io/${{ (startsWith(github.event.workflow_run.head_branch || github.ref_name, 'v*.*')) && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
-      GHCR_IMAGE: ghcr.io/${{ (startsWith(github.event.workflow_run.head_branch || github.ref_name, 'v*.*')) && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ vars.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
-
-      - name: Build and push Docker image with SHA tag
-        id: push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          provenance: false
-          sbom: false
-          platforms: linux/${{ matrix.arch }}
-          tags: |
-            ${{ env.DOCKER_HUB_IMAGE }}:${{ github.event.workflow_run.head_sha || github.sha }}-${{ matrix.arch }}
-            ${{ env.GHCR_IMAGE }}:${{ github.event.workflow_run.head_sha || github.sha }}-${{ matrix.arch }}
-          cache-from: type=gha,scope=docker-build-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=docker-build-${{ matrix.arch }}
-
-  create-manifest:
-    needs: build-and-push-platform
+  publish:
+    name: promote tested image
     runs-on: ubuntu-26.04
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    env:
-      DOCKER_HUB_IMAGE: docker.io/${{ (startsWith(github.event.workflow_run.head_branch || github.ref_name, 'v*.*')) && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
-      GHCR_IMAGE: ghcr.io/${{ (startsWith(github.event.workflow_run.head_branch || github.ref_name, 'v*.*')) && vars.DOCKER_ORG_NAME || github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
+    timeout-minutes: 20
     steps:
+      - uses: docker/setup-buildx-action@v4.2.0
+
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ vars.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
+      - name: Resolve seven-character SHA
+        id: sha
+        uses: docker/metadata-action@v6.2.0
         with:
-          images: |
-            ${{ env.DOCKER_HUB_IMAGE }}
-            ${{ env.GHCR_IMAGE }}
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.event.workflow_run.head_branch == 'main' }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,format=short,prefix=
+          images: ${{ env.PRIVATE_DOCKER_IMAGE }}
+          tags: type=match,value=${{ inputs.source_sha }},pattern=^([0-9a-f]{7})[0-9a-f]{33}$,group=1
 
-      - name: Create and push manifest
-        id: manifest
-        run: |
-          tags_with_commas="${{ steps.meta.outputs.csv_tags }}"
-          tags_with_spaces=$(echo "$tags_with_commas" | tr ',' ' ')
-          manifest_digest=""
-
-          for tag in $tags_with_spaces; do
-            base_image=$(echo "$tag" | cut -d: -f1)
-            echo "Creating manifest for $tag"
-            docker buildx imagetools create -t "$tag" \
-              "${base_image}:${{ github.event.workflow_run.head_sha || github.sha }}-amd64" \
-              "${base_image}:${{ github.event.workflow_run.head_sha || github.sha }}-arm64"
-            if [[ "$tag" == *":latest" ]]; then
-              manifest_digest=$(docker buildx imagetools inspect "$tag" --format '{{json .Manifest.Digest}}' | tr -d '"')
-            fi
-          done
-          echo "digest=$manifest_digest" >> $GITHUB_OUTPUT
-
-      - name: Attest Provenance (Docker Hub)
-        if: steps.manifest.outputs.digest != ''
-        uses: actions/attest@v4
+      - name: Resolve release version
+        id: release
+        if: inputs.channel == 'release'
+        uses: docker/metadata-action@v6.2.0
         with:
-          subject-name: ${{ env.DOCKER_HUB_IMAGE }}
-          subject-digest: ${{ steps.manifest.outputs.digest }}
+          images: ${{ env.PUBLIC_DOCKER_IMAGE }}
+          tags: type=match,value=${{ inputs.version }},pattern=^v([0-9]+\.[0-9]+\.[0-9]+)$,group=1
+
+      - name: Resolve release series
+        id: series
+        if: inputs.channel == 'release'
+        uses: docker/metadata-action@v6.2.0
+        with:
+          images: ${{ env.PUBLIC_DOCKER_IMAGE }}
+          tags: type=match,value=${{ inputs.version }},pattern=^v[0-9]+\.[0-9]+\.[0-9]+(?:\.dev[0-9]+)?$,group=1
+
+      - name: Validate commit SHA
+        run: test -n "${{ steps.sha.outputs.version }}"
+
+      - name: Validate stable release tag
+        if: inputs.channel == 'release'
+        run: test -n "${{ steps.release.outputs.version }}"
+
+      - name: Publish owner SHA tag to Docker Hub
+        run: docker buildx imagetools create --tag "${PRIVATE_DOCKER_IMAGE}:${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+
+      - name: Publish owner SHA tag to GHCR
+        run: docker buildx imagetools create --tag "${PRIVATE_GHCR_IMAGE}:${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+
+      - name: Publish edge to Docker Hub
+        if: inputs.channel == 'edge'
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:edge" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+
+      - name: Publish edge to GHCR
+        if: inputs.channel == 'edge'
+        run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:edge" "${PUBLIC_DOCKER_IMAGE}:edge"
+
+      - name: Publish release version to Docker Hub
+        if: inputs.channel == 'release'
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ steps.release.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+
+      - name: Publish release series to Docker Hub
+        if: inputs.channel == 'release'
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ steps.series.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+
+      - name: Publish latest to Docker Hub
+        if: inputs.channel == 'release'
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:latest" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+
+      - name: Publish release version to GHCR
+        if: inputs.channel == 'release'
+        run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:${{ steps.release.outputs.version }}" "${PUBLIC_DOCKER_IMAGE}:${{ steps.release.outputs.version }}"
+
+      - name: Publish release series to GHCR
+        if: inputs.channel == 'release'
+        run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:${{ steps.series.outputs.version }}" "${PUBLIC_DOCKER_IMAGE}:${{ steps.series.outputs.version }}"
+
+      - name: Publish latest to GHCR
+        if: inputs.channel == 'release'
+        run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:latest" "${PUBLIC_DOCKER_IMAGE}:latest"
+
+      - name: Read edge digest
+        id: edge-digest
+        if: inputs.channel == 'edge'
+        run: echo "digest=$(docker buildx imagetools inspect "${PUBLIC_DOCKER_IMAGE}:edge" --format '{{.Manifest.Digest}}')" >> "$GITHUB_OUTPUT"
+
+      - name: Attest edge on Docker Hub
+        if: inputs.channel == 'edge'
+        uses: actions/attest@v4.2.1
+        with:
+          subject-name: ${{ env.PUBLIC_DOCKER_IMAGE }}
+          subject-digest: ${{ steps.edge-digest.outputs.digest }}
           push-to-registry: true
-          
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          path: ./
-          artifact-name: sbom.cyclonedx.json
-          output-file: sbom.cyclonedx.json
-          format: cyclonedx-json
 
-      - name: Attest SBOM (Docker Hub)
-        if: steps.manifest.outputs.digest != ''
-        uses: actions/attest@v4
+      - name: Read release digest
+        id: release-digest
+        if: inputs.channel == 'release'
+        run: echo "digest=$(docker buildx imagetools inspect "${PUBLIC_DOCKER_IMAGE}:${{ steps.release.outputs.version }}" --format '{{.Manifest.Digest}}')" >> "$GITHUB_OUTPUT"
+
+      - name: Attest release on Docker Hub
+        if: inputs.channel == 'release'
+        uses: actions/attest@v4.2.1
         with:
-          subject-name: ${{ env.DOCKER_HUB_IMAGE }}
-          subject-digest: ${{ steps.manifest.outputs.digest }}
-          sbom-path: 'sbom.cyclonedx.json'
+          subject-name: ${{ env.PUBLIC_DOCKER_IMAGE }}
+          subject-digest: ${{ steps.release-digest.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,10 +5,12 @@ name: Upload Python Package
 
 on:
   workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+    workflows: 
+      - CI
+    types:
+      - completed
     branches:
-      - 'v[0-9]*'
+      - 'v*.*.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
@@ -19,13 +21,11 @@ permissions:
 
 jobs:
   release-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     # Only run if CI succeeded AND it was a tag push.
     # Exclude PRs to avoid accidental triggers/publishing.
     if: |
-      github.event_name == 'workflow_run' && 
       github.event.workflow_run.conclusion == 'success' && 
-      github.event.workflow_run.event != 'pull_request' &&
       github.event.workflow_run.event == 'push' &&
       startsWith(github.event.workflow_run.head_branch, 'v') &&
       github.event.workflow_run.head_repository.full_name == github.repository
@@ -38,7 +38,7 @@ jobs:
       version: ${{ steps.check_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
@@ -51,8 +51,12 @@ jobs:
           # Regex for stable release: vX.Y.Z
           if [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "is_stable=true" >> $GITHUB_OUTPUT
+          # Regex for dev release: vX.Y.Z.devN
+          elif [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$ ]]; then
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
           else
-            echo "is_stable=false" >> $GITHUB_OUTPUT
+            echo "Unsupported version tag: $VERSION" >&2
+            exit 1
           fi
 
       - name: Set up uv

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,121 +1,79 @@
-# This workflow will upload a Python Package to PyPI when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-name: Upload Python Package
+name: Python Publish
 
 on:
-  workflow_run:
-    workflows: 
-      - CI
-    types:
-      - completed
-    branches:
-      - 'v*.*.*'
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: Name of the CI artifact containing tested distributions
+        required: true
+        type: string
+      repository:
+        description: Package repository to publish to
+        required: true
+        type: string
+      version:
+        description: Package version to publish
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  group: python-publish-${{ inputs.repository }}-${{ inputs.version }}
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  release-build:
+  pypi-publish:
+    name: Publish to PyPI
+    if: inputs.repository == 'pypi'
     runs-on: ubuntu-26.04
-    # Only run if CI succeeded AND it was a tag push.
-    # Exclude PRs to avoid accidental triggers/publishing.
-    if: |
-      github.event.workflow_run.conclusion == 'success' && 
-      github.event.workflow_run.event == 'push' &&
-      startsWith(github.event.workflow_run.head_branch, 'v') &&
-      github.event.workflow_run.head_repository.full_name == github.repository
     permissions:
-      contents: read
       id-token: write
       attestations: write
-    outputs:
-      is_stable: ${{ steps.check_version.outputs.is_stable }}
-      version: ${{ steps.check_version.outputs.version }}
-
+    environment:
+      name: pypi
+      url: https://pypi.org/project/PyStormTracker/${{ inputs.version }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - name: Retrieve tested distributions
+        uses: actions/download-artifact@v8
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
-
-      - name: Check version type
-        id: check_version
-        run: |
-          VERSION=${{ github.event.workflow_run.head_branch }}
-          echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
-          # Regex for stable release: vX.Y.Z
-          if [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "is_stable=true" >> $GITHUB_OUTPUT
-          # Regex for dev release: vX.Y.Z.devN
-          elif [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$ ]]; then
-            echo "is_stable=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unsupported version tag: $VERSION" >&2
-            exit 1
-          fi
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v9.0.0
-        with:
-          enable-cache: true
-
-      - name: Build release distributions
-        run: uv build --wheel --sdist
+          name: ${{ inputs.artifact_name }}
+          path: dist/
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: "dist/*"
+          subject-path: dist/*
 
-      - name: Upload distributions
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-dists
-          path: dist/
-
-  pypi-publish:
-    runs-on: ubuntu-latest
-    needs:
-      - release-build
-    if: needs.release-build.outputs.is_stable == 'true'
-    permissions:
-      id-token: write
-    environment:
-      name: pypi
-      url: https://pypi.org/project/PyStormTracker/${{ needs.release-build.outputs.version }}
-    steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v8
-        with:
-          name: release-dists
-          path: dist/
-      - name: Publish release distributions to PyPI
+      - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
 
   test-pypi-publish:
-    runs-on: ubuntu-latest
-    needs:
-      - release-build
-    if: needs.release-build.outputs.is_stable == 'false'
+    name: Publish to TestPyPI
+    if: inputs.repository == 'testpypi'
+    runs-on: ubuntu-26.04
     permissions:
       id-token: write
+      attestations: write
     environment:
       name: testpypi
-      url: https://test.pypi.org/project/PyStormTracker/${{ needs.release-build.outputs.version }}
+      url: https://test.pypi.org/project/PyStormTracker/${{ inputs.version }}
     steps:
-      - name: Retrieve release distributions
+      - name: Retrieve tested distributions
         uses: actions/download-artifact@v8
         with:
-          name: release-dists
+          name: ${{ inputs.artifact_name }}
           path: dist/
-      - name: Publish release distributions to TestPyPI
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/*
+
+      - name: Publish distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,18 +36,18 @@ jobs:
       url: https://pypi.org/project/PyStormTracker/${{ inputs.version }}
     steps:
       - name: Retrieve tested distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: dist/
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@v4.1.1
         with:
           subject-path: dist/*
 
       - name: Publish distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.14.2
         with:
           packages-dir: dist/
 
@@ -63,18 +63,18 @@ jobs:
       url: https://test.pypi.org/project/PyStormTracker/${{ inputs.version }}
     steps:
       - name: Retrieve tested distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.artifact_name }}
           path: dist/
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@v4.1.1
         with:
           subject-path: dist/*
 
       - name: Publish distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,6 +29,7 @@ jobs:
     if: inputs.repository == 'pypi'
     runs-on: ubuntu-26.04
     permissions:
+      contents: read
       id-token: write
       attestations: write
     environment:
@@ -56,6 +57,7 @@ jobs:
     if: inputs.repository == 'testpypi'
     runs-on: ubuntu-26.04
     permissions:
+      contents: read
       id-token: write
       attestations: write
     environment:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,34 @@
 # PyStormTracker Repository Instructions
 
-Foundational mandates and engineering standards for `PyStormTracker`. These take precedence over general defaults.
+These instructions apply to automated changes in this repository.
 
-## 1. Core Mandates
+## References
 
-- **Hodges Parity**: MUST maintain algorithmic parity with TRACK (Hodges 1994, 1995, 1999) as detailed in `docs/hodges.md`. Core kernels MUST use Numba.
-- **Vectorized Architecture**: MUST use the array-backed data model and JIT-optimized kernels described in `docs/architecture.md`.
-- **Validation**: Parallel results MUST be bit-wise identical to serial execution. Use Gather-then-Link orchestration.
-- **Geometry**: All distance calculations MUST use the great-circle dot product formula with precision clamping.
-- **Backends**: Simple supports serial, Dask, and MPI tracking. Hodges and HEALPix are serial-only until Gather-then-Link parallel implementations exist.
+- Read `docs/architecture.md` before changing data models, tracker interfaces, preprocessing, parallel execution, testing, packaging, or CI/CD.
+- Read `docs/hodges.md` before changing Hodges detection, linking, optimization, constraints, or sub-grid refinement.
+- Read the relevant [CLI](docs/cli.md) and [roadmap](docs/roadmap.md) documents before changing documented behavior.
 
-## 2. Engineering Standards
+## Scientific and behavioral requirements
 
-- **Flexible APIs**: All `track()` implementations MUST accept `**kwargs` for cross-algorithm compatibility.
-- **I/O**: MUST use coordinate-aware Xarray NetCDF/GRIB handling via `DataLoader`. Centralize remote test data in `tests/utils.py`; integrations using checked-in or versioned PyStormTracker-Data fixtures count as verified for their tested scope.
-- **Typing**: MUST NOT use `Any` typing. Provide explicit type annotations for all declarations.
-- **Documentation**: State behavior, defaults, support limits, and evidence. Distinguish implemented, repository-tested, externally validated, and planned work. Preserve domain-specific scientific and algorithmic terms; define acronyms on first use and simplify prose without replacing precise terminology with generic wording. Do not use promotional wording or claim parity/performance without a named comparison.
-- **No Auto-Commit**: NEVER stage or commit changes unless specifically and explicitly requested by the user.
-- **Tooling**: MUST use `uv` for package management, environment handling, and running tools (e.g., `uv run ruff`, `uv run pytest`).
-- **Documentation Persistence**: Preserve existing technical documentation and design rationale unless explicitly obsoleted.
-- **Defaults**: CLI/orchestrator filtering and subgrid refinement are tri-state. Omitted means off for Simple and on for Hodges/HEALPix; direct tracker defaults must remain algorithm-specific.
-- **VO Tests**: Production vorticity defaults to `1e-5`. The legacy Simple VO regression and bounded Hodges integration use `1e-4` only to match historical data and control runtime.
-- **SHTns**: Keep SHTns out of production dependencies. It may be used by a standalone, reproducible comparison benchmark against ducc0.
+- Preserve algorithm-specific behavior, defaults, thresholds, output formats, and supported backends unless the requested change requires otherwise.
+- Maintain documented TRACK/Hodges parity. Do not replace the original method with an approximation. Alternative methods must be explicit options.
+- Parallel implementations must reproduce deterministic serial results for the tested scope.
+- Do not claim parity, accuracy, performance, or external validation without identifying the comparison and evidence.
+
+## Engineering requirements
+
+- Use `uv` for dependency management, environment synchronization, builds, and development commands.
+- Keep numerical kernels vectorized or Numba-compiled where required by the architecture.
+- Do not introduce persistent object-per-center or object-per-point storage in performance-critical paths.
+- Provide explicit type annotations. Do not introduce `Any`.
+- Keep tracker implementations compatible with the shared protocol, including `**kwargs` where required for cross-algorithm calls.
+- Use `DataLoader` and coordinate-aware Xarray paths for supported meteorological inputs.
+- Add or update focused tests for behavioral changes. Preserve historical fixtures and tolerances unless the change corrects them explicitly.
+
+## Documentation and change control
+
+- Use direct technical and scientific prose. Preserve established terminology and define acronyms when first used.
+- Avoid promotional language, buzzwords, unsupported adjectives, and claims broader than the available evidence.
+- Distinguish implemented behavior, repository-tested behavior, external validation, and planned work.
+- Keep changes limited to the requested task. Preserve design rationale unless it is obsolete and the replacement is documented.
+- Do not stage, commit, push, publish, or create releases unless explicitly requested.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin uv for reproducible builds; Dependabot can update this reference.
-COPY --from=ghcr.io/astral-sh/uv:0.12.0 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.1 /uv /uvx /bin/
 
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,62 +1,43 @@
 # --- Build Stage ---
 FROM python:3.13-slim AS builder
 
-ARG TARGETARCH
-
-# Prevent uv from creating a virtualenv that might be hard to move
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=0
 
 WORKDIR /app
 
-# Install build dependencies. ducc0 requires a C++17 compiler (g++).
+# ducc0 may need a C++17 compiler when no compatible wheel is available.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Pin uv for reproducible builds; Dependabot can update this reference.
+COPY --from=ghcr.io/astral-sh/uv:0.12.0 /uv /uvx /bin/
 
-# 1. Copy only dependency files for better layer caching.
 COPY pyproject.toml uv.lock ./
-
-# 2. Install third-party dependencies first (including extras).
-# Use cache mount for uv to persist downloads and build artifacts.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-workspace --extra grib --extra netcdf4 --no-editable
 
-# 3. Copy only necessary source files for the final installation step.
 COPY src/ ./src/
 COPY README.md ./
-
-# 4. Final installation of the project package itself.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --extra grib --extra netcdf4 --no-editable
-
 
 # --- Runtime Stage ---
 FROM python:3.13-slim
 
 WORKDIR /app
-
-# Create data directory for mounting
 RUN mkdir /data && chmod 777 /data
 
-# Copy the environment from the builder
 COPY --from=builder /app/.venv /app/.venv
 
-# Ensure the virtualenv is used by default
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1
 
-# Add a non-root user for security
 RUN useradd -m pst
 USER pst
 
-# Volume for data persistence
 VOLUME /data
-
-# Default command
 ENTRYPOINT ["stormtracker"]
 CMD ["--help"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,8 @@ Ordinary feature-branch pushes do not run CI independently. This prevents a bran
 Pull requests execute a representative suite:
 
 - code-quality and type checks;
-- Python 3.13 unit tests and Ubuntu AMD64 integration tests;
+- Python 3.13 unit tests with coverage and Ubuntu AMD64 integration tests without
+  the slow marker;
 - wheel installation, documentation, and dependency review;
 - a local AMD64 Docker build, smoke test, and vulnerability scan.
 
@@ -144,6 +145,9 @@ Pushes to `main`, version tags, and manual CI runs execute the full suite:
 - slow integration tests;
 - wheel and source-distribution installation tests;
 - native AMD64 and ARM64 staging-image builds.
+
+Pull-request Docker jobs do not receive registry credentials or push images. Native
+staging images are built only after the full non-Docker suite succeeds.
 
 ### 6.3 Tested Docker Staging Images
 
@@ -176,7 +180,17 @@ Release tags are validated with an explicit stable-version expression equivalent
 
 ### 6.5 Python Publishing and Dependency Updates
 
-Python publishing remains in `.github/workflows/python-publish.yml` and runs only after successful CI for a version tag. Docker republishing does not republish the Python package.
+CI validates that a version tag points to a commit reachable from `main` and that
+the package version matches the tag without its leading `v`. It then calls the
+reusable Python publishing workflow with the distributions built and package-tested
+in the same CI run. The reusable workflow has no manual-dispatch trigger.
+
+Stable tags matching `vX.Y.Z` publish to PyPI after the protected `pypi`
+environment approves the job. Development tags matching `vX.Y.Z.devN` publish to
+TestPyPI after the protected `testpypi` environment approves the job. Development
+tags do not publish Docker images. Docker `edge` follows the newest successful
+`main` CI run, and Docker `latest` changes only during a successful stable-tag
+release. Docker republishing does not republish the Python package.
 
 Dependabot checks `uv`, GitHub Actions, and Docker dependencies daily. Minor and patch Python updates and GitHub Actions updates may be grouped to reduce pull-request volume. Major Python updates and Docker image updates remain separate for diagnosis.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,122 +1,209 @@
 # PyStormTracker Architecture
 
-This document describes the data model, tracker interfaces, preprocessing, and execution paths in PyStormTracker.
+This document describes the data model, tracker interfaces, preprocessing, execution paths, testing, and release workflows in PyStormTracker.
 
 ## 1. Architecture Principles
 
 The architecture has four main features:
-1.  **Unified API (Tracker Protocol):** A structural interface that allows the CLI and Python API to support multiple tracking algorithms (e.g., `SimpleTracker`, `HodgesTracker`) interchangeably.
-2.  **Centralized Threshold Management:** Standard detection thresholds (for example, `1e-5` for vorticity and `0.0` for MSL) are defined in `models/constants.py` and shared by tracker paths.
-3.  **Vectorization and Numba JIT:** Numerical operations use NumPy broadcasting and cached, GIL-free Numba kernels where suitable, avoiding Python loops in the detection and linking kernels.
-4.  **Gather-then-Link:** Simple Dask and MPI execution distribute detection, gather raw detections in time order, and run one linking pass.
 
----
+1. **Unified API (`Tracker` protocol):** A structural interface allows the CLI and Python API to use `SimpleTracker`, `HodgesTracker`, and `HealpixTracker` through common orchestration code.
+2. **Centralized constants:** Standard constants such as radius of earth, and detection thresholds, are defined in `models/constants.py` and shared by trackers.
+3. **Vectorization and Numba JIT:** Numerical operations use NumPy broadcasting and cached, GIL-free Numba kernels where suitable. Detection and linking kernels avoid Python loops where practical.
+4. **Gather-then-Link:** Simple Dask and MPI execution distribute detection, gather raw detections in time order, and run one linking pass.
 
 ## 2. Core Components
 
 ### 2.1 Array-Backed Data Models (`Tracks`, `Track`, `Center`)
+
 The data models use contiguous array-backed storage:
-*   **`Tracks`**: The central container holding one-dimensional NumPy arrays for `track_ids`, `times`, `lats`, `lons`, and a dictionary of additional meteorological variables.
-*   **`Track`**: A lightweight view into the `Tracks` arrays for one cyclone track.
-*   **`Center`**: A dataclass used for cyclone center detection.
 
-This layout avoids storing one persistent Python object per center, reduces object-allocation overhead, and supports NumPy broadcasting, selection, and serialization between parallel workers.
+- **`Tracks`:** The central container holding one-dimensional NumPy arrays for `track_ids`, `times`, `lats`, `lons`, and additional meteorological variables.
+- **`Track`:** A lightweight view into the `Tracks` arrays for one cyclone track.
+- **`Center`:** A dataclass used during cyclone-center detection.
 
-### 2.2 Shared DataLoader
-Data loading is encapsulated in a dedicated `DataLoader` class (`io/data_loader.py`). This component handles:
-*   **Format handling**: Opens NetCDF through `h5netcdf` or `netCDF4`, GRIB through `cfgrib`, and Zarr through `zarr` engines.
-*   **Remote data**: Supports Zarr stores over HTTP, S3, and GS through `fsspec` when the optional Zarr dependencies are installed.
-*   **Variable and coordinate mapping**: Resolves common field aliases such as `msl`/`slp` and latitude/longitude/time coordinate aliases.
-*   **Grid metadata**: Detects regular latitude-longitude, full Gaussian, reduced Gaussian, projected `x/y`, and HEALPix coordinates and retains metadata required by spherical harmonic transforms and map projections.
+This layout avoids one persistent Python object per center, reduces allocation overhead, and supports NumPy selection, broadcasting, and serialization between workers.
 
-### 2.3 Heuristic Tracking Implementation (SimpleTracker)
-Trajectory construction in the Simple tracker uses NumPy broadcasting to construct great-circle distance matrices from clamped unit-vector dot products. Candidate centers are sorted lexicographically before deterministic greedy nearest-neighbor matching between consecutive time steps.
+### 2.2 Shared `DataLoader`
 
-### 2.4 Optimization-Based Tracking Implementation (HodgesTracker)
-The `HodgesTracker` implements methods based on TRACK (Hodges 1994, 1995, 1999):
-*   **Object-Based Detection**: Features are identified using `Thresholding -> Connected Component Labeling (CCL) -> Object Filtering -> Local Extrema`.
-*   **Modified Greedy Exchange (MGE)**: An iterative algorithm that swaps points between tracks to minimize a total cost function.
-*   **Spherical Cost Function**: Penalizes changes in the tangent direction and displacement magnitude of consecutive track segments.
-*   **Adaptive Constraints**: Adjusts maximum displacement ($d_{max}$) and smoothness limits ($\psi_{max}$) from regional zones and track displacement.
-*   **Sub-grid Refinement**: Fits a local quadratic surface around each eligible extremum. On periodic global grids, a spherical spline value is also evaluated at that center.
+Data loading is encapsulated in `DataLoader` (`io/data_loader.py`). It handles:
+
+- **Formats:** NetCDF through `h5netcdf` or `netCDF4`, GRIB through `cfgrib`, and Zarr through `zarr`.
+- **Remote data:** Zarr stores over HTTP, S3, and Google Cloud Storage through `fsspec` when the optional Zarr dependencies are installed.
+- **Variable and coordinate mapping:** Common field aliases such as `msl` and `slp`, and latitude, longitude, and time coordinate aliases.
+- **Grid metadata:** Regular latitude-longitude, full Gaussian, reduced Gaussian, projected `x/y`, and HEALPix coordinates, including metadata required by spherical harmonic transforms and map projections.
+
+### 2.3 Heuristic Tracking (`SimpleTracker`)
+
+The Simple tracker constructs great-circle distance matrices from clamped unit-vector dot products using NumPy broadcasting. Candidate centers are sorted lexicographically before deterministic greedy nearest-neighbor matching between consecutive time steps.
+
+### 2.4 Optimization-Based Tracking (`HodgesTracker`)
+
+`HodgesTracker` implements methods based on TRACK (Hodges 1994, 1995, 1999):
+
+- **Object-based detection:** Thresholding, connected-component labeling, object filtering, and local-extrema detection.
+- **Modified Greedy Exchange (MGE):** Iterative exchange of points between tracks to reduce the total cost function.
+- **Spherical cost function:** Penalties for changes in tangent direction and displacement magnitude between consecutive track segments.
+- **Adaptive constraints:** Regional and displacement-dependent maximum-displacement and smoothness limits.
+- **Sub-grid refinement:** Local quadratic fitting around eligible extrema. A spherical spline value may also be evaluated on periodic global grids.
+
+The detailed algorithmic requirements and TRACK comparison scope are documented in [Hodges Tracking](hodges.md).
 
 ### 2.5 Parallel Pipeline (Gather-then-Link)
 
 Simple parallel execution uses the following sequence:
-1.  **Parallel Detection**: Assigned time chunks are distributed across Dask or MPI workers. Each worker runs Numba kernels to find centers and returns raw coordinate arrays.
-2.  **Centralized Linking**: The main process gathers the raw detections from all workers and performs a single sequential link. 
 
-Detection contains the frame-local Numba kernels and can be partitioned without making link decisions at chunk boundaries. Centralized linking therefore avoids track merging across independently linked chunks. Repository integrations compare complete serial, Dask, and MPI Simple outputs using versioned test data. Hodges supports serial chunked detection followed by one linking pass. Hodges and HEALPix do not currently provide Dask or MPI tracking.
+1. Assigned time chunks are distributed across Dask or MPI workers.
+2. Each worker runs frame-local detection kernels and returns raw coordinate arrays.
+3. The main process gathers detections in global time order.
+4. One sequential linking pass constructs the tracks.
 
----
+Detection can be partitioned without making link decisions at chunk boundaries. Centralized linking avoids merging independently linked chunks. Repository integration tests compare complete serial, Dask, and MPI Simple outputs using versioned test data.
 
-## 3. Command Line Interface Architecture
+Hodges supports serial chunked detection followed by one linking pass. Hodges and HEALPix do not currently provide Dask or MPI tracking.
+
+## 3. Command-Line Interface Architecture
 
 PyStormTracker uses `argparse` subcommands.
 
 ### 3.1 Modular Router Pattern
-The `cli.py` module acts as a thin entry point. It utilizes `argparse` subparsers to delegate argument definition and execution to specialized modules:
-*   **`track.py`**: Core tracking pipeline.
-*   **`sample.py`**: Post-processing for variable enrichment (e.g., sampling precipitation along tracks).
-*   **`compare.py`**: Intercomparison utilities for matching tracks between datasets.
-*   **`convert.py`**: IO conversion and visualization generation.
+
+`cli.py` is a thin entry point. It delegates argument definition and execution to focused modules:
+
+- **`track.py`:** Detection and trajectory construction.
+- **`sample.py`:** Sampling secondary variables, such as precipitation, along tracks.
+- **`compare.py`:** Intercomparison and matching of track datasets.
+- **`convert.py`:** Output conversion and supported visualization generation.
 
 ### 3.2 Decoupled Analysis Commands
-Tracking, secondary-variable sampling, track comparison, and format conversion are separate commands. A primary track file can be reused when sampling additional meteorological fields or comparing datasets, without rerunning detection and trajectory linking on the original three-dimensional field.
 
----
+Tracking, secondary-variable sampling, track comparison, and format conversion are separate commands. A track file can be reused for sampling or comparison without rerunning detection and trajectory linking on the original field.
 
 ## 4. The `Tracker` Protocol
 
-The `Tracker` Protocol (defined in `src/pystormtracker/models/tracker.py`) provides a standardized interface for all tracking algorithms:
+The `Tracker` protocol is defined in `src/pystormtracker/models/tracker.py` and provides a common interface for tracking algorithms:
 
 ```python
 import pystormtracker as pst
 
-# Instantiate any compliant tracker
 tracker = pst.SimpleTracker()
 
-# Standardized .track() method
 tracks = tracker.track(
-    infile="era5_msl.nc", varname="msl", start_time="2025-01-01", backend="dask"
+    infile="era5_msl.nc",
+    varname="msl",
+    start_time="2025-01-01",
+    backend="dask",
 )
 
-# Standardized export
 tracks.write("output.txt", format="imilast")
 ```
 
----
+Tracker implementations retain algorithm-specific defaults while accepting shared orchestration arguments. The high-level API and CLI pass algorithm-specific options through `**kwargs` where required.
 
-## 5. Planned Architecture Work
+## 5. Testing and Validation
+
+The test suite has several levels:
+
+- **Unit tests:** Models, numerical kernels, geometry, parsing, and isolated behavior.
+- **Integration tests:** Data loading, complete tracker paths, optional dependencies, parallel backends, and output formats.
+- **Slow integration tests:** Larger scientific comparisons and more expensive end-to-end cases.
+- **Package smoke tests:** Wheel and source-distribution builds installed with standard `pip` in clean environments.
+- **Container smoke tests:** CLI startup, package import, and vulnerability scanning of the built image.
+
+`uv` manages development and CI environments. Package smoke tests use `pip` because they test the installed distribution as users receive it.
+
+The minimum-direct-dependency test resolves with `uv sync --resolution lowest-direct` and runs with `uv run --no-sync` so the environment is not replaced by the normal lockfile resolution.
+
+Parallel results must be deterministic for the tested scope. Serial, Dask, and MPI Simple outputs are compared as complete track results rather than only by counts or summary statistics.
+
+## 6. Continuous Integration and Publishing
+
+### 6.1 CI Triggers and Duplicate Runs
+
+The `CI` workflow runs for:
+
+- pull requests, including each new commit pushed to an open pull request;
+- pushes to `main`;
+- version tags matching the broad `v*` trigger;
+- manual workflow dispatch.
+
+Ordinary feature-branch pushes do not run CI independently. This prevents a branch push and its pull request from running the same CI suite twice. Concurrency cancellation stops superseded pull-request and `main` runs. Tag runs are not cancelled.
+
+### 6.2 Pull-Request and Full Test Suites
+
+Pull requests execute a representative suite:
+
+- code-quality and type checks;
+- Python 3.13 unit tests and Ubuntu AMD64 integration tests;
+- wheel installation, documentation, and dependency review;
+- a local AMD64 Docker build, smoke test, and vulnerability scan.
+
+Pushes to `main`, version tags, and manual CI runs execute the full suite:
+
+- supported Python versions, including minimum-direct-dependency and free-threaded tests;
+- Ubuntu AMD64 and ARM64, Ubuntu 24.04 and 26.04 compatibility, Windows AMD64, and macOS ARM64 integration tests;
+- slow integration tests;
+- wheel and source-distribution installation tests;
+- native AMD64 and ARM64 staging-image builds.
+
+### 6.3 Tested Docker Staging Images
+
+After the non-Docker full suite succeeds, CI builds native platform images on:
+
+- `ubuntu-26.04` for `linux/amd64`;
+- `ubuntu-26.04-arm` for `linux/arm64`.
+
+Each platform image is pushed to the private staging repository `docker.io/mwyau/pystormtracker` under a tag containing the CI run ID, run attempt, and architecture. CI pulls and tests the exact pushed digest. After both platform jobs succeed, CI creates one private multi-platform staging manifest tagged `ci-<run-id>-<run-attempt>`.
+
+Pull-request Docker builds are local and do not receive registry credentials.
+
+### 6.4 Docker Publishing
+
+After the staging manifest is created, CI calls the reusable `Docker Publish` workflow to promote it without rebuilding. The CI run ID and run attempt identify the exact staging image. Publication applies the following tags:
+
+| Source | `mwyau/pystormtracker` | `xddd/pystormtracker` |
+| --- | --- | --- |
+| `main` | seven-character commit SHA | `edge` |
+| stable tag `v0.6.0` | seven-character commit SHA | `0.6.0`, `0.6`, `latest` |
+| manual private promotion | seven-character commit SHA | none |
+
+The completed Docker Hub manifests are copied to the corresponding GHCR repositories without rebuilding. Public `edge` and release manifests are attested on Docker Hub only; GHCR copies are not separately attested.
+
+Manual dispatch can promote an existing tested staging tag through the `private`, `edge`, or `release` channel.
+
+The publisher contains no recovery build path. If a private staging image has been deleted, the corresponding CI run must be rerun to rebuild and retest it before publication. This keeps image construction and testing in CI and keeps the publishing workflow limited to validation, tagging, copying, and attestation.
+
+Release tags are validated with an explicit stable-version expression equivalent to `vX.Y.Z`. The broad workflow trigger is not treated as version validation.
+
+### 6.5 Python Publishing and Dependency Updates
+
+Python publishing remains in `.github/workflows/python-publish.yml` and runs only after successful CI for a version tag. Docker republishing does not republish the Python package.
+
+Dependabot checks `uv`, GitHub Actions, and Docker dependencies daily. Minor and patch Python updates and GitHub Actions updates may be grouped to reduce pull-request volume. Major Python updates and Docker image updates remain separate for diagnosis.
+
+## 7. Planned Architecture Work
 
 Current planned work includes:
 
-*   **Xarray generalized ufuncs:** Spectral filtering and kinematic derivatives use `xr.apply_ufunc(..., dask="parallelized")`; detection still uses explicit time partitioning.
-*   **Lazy evaluation and thread topology:** Reduce eager frame loading and define ducc0 and Numba thread counts when Dask threads or MPI processes distribute work.
-*   **Spatial indexing:** Evaluate `scipy.spatial.cKDTree` or another spherical candidate index to reduce the $O(N \times M)$ candidate-search cost in dense Simple linking workloads.
-*   **Additional backends:** Hodges and HEALPix parallel tracking require Gather-then-Link implementations and serial-parallel equality tests.
+- **Xarray generalized ufuncs:** Spectral filtering and kinematic derivatives use `xr.apply_ufunc(..., dask="parallelized")`; detection still uses explicit time partitioning.
+- **Lazy evaluation and thread topology:** Reduce eager frame loading and define `ducc0` and Numba thread counts when Dask threads or MPI processes distribute work.
+- **Spatial indexing:** Evaluate `scipy.spatial.cKDTree` or another spherical candidate index to reduce the $O(N \times M)$ candidate-search cost in dense Simple linking workloads.
+- **Additional backends:** Hodges and HEALPix parallel tracking require Gather-then-Link implementations and serial-parallel equality tests.
 
-For more details on specific planned implementations, see the [Roadmap](roadmap.md).
+For planned features, see the [Roadmap](roadmap.md).
 
----
+## 8. Performance Benchmarks
 
-## 6. Performance Benchmarks
-
-The benchmark page records Simple tracker timings for versions `v0.3.3` and `v0.4.0` on one workstation.
+The benchmark page records Simple tracker timings for versions `v0.3.3` and `v0.4.0`.
 
 Detailed execution timings (breaking down Detection, Linking, Export, and I/O Overhead) across Serial, Dask, and MPI backends for both standard and high-resolution ERA5 datasets are available in the [Benchmark Report](benchmark.md).
 
----
-
 ## Appendix: Evolution from Legacy Architecture
 
-The current architecture differs from the earlier nested-object design as follows.
-
 | Feature | Legacy Architecture (v0.0.2) | Current Architecture (v0.4.0+) |
-| :--- | :--- | :--- |
-| **Data Storage** | Nested lists of `Center` and `Track` objects. | Flat, C-contiguous NumPy arrays. |
-| **Parallelism** | Threaded tree reduction. | Simple: threaded Dask or MPI detection, then centralized linking. |
-| **Linking Strategy** | Tree reduction across chunks. | Parallel detection and centralized linking with serial-equality tests. |
-| **Linker** | $O(N^2)$ nested Python loops. | Vectorized NumPy great-circle distance matrix and deterministic greedy matching. |
+| --- | --- | --- |
+| **Data storage** | Nested lists of `Center` and `Track` objects. | Flat, C-contiguous NumPy arrays. |
+| **Parallelism** | Threaded tree reduction. | Parallel detection followed by centralized linking. |
+| **Linking strategy** | Tree reduction across chunks. | Ordered detection gathering and one linking pass with serial-equality tests. |
+| **Linker** | $O(N^2)$ nested Python loops. | Vectorized great-circle distance matrices and deterministic greedy matching. |
 | **Algorithms** | Simple only. | Simple, Hodges-based, and HEALPix trackers. |
 | **I/O** | Many small lazy-loaded chunks. | Xarray reads coordinated through `DataLoader`. |


### PR DESCRIPTION
Summary

- Run the representative PR suite and the full trusted suite from one CI workflow using selected test matrices.
- Build and test Python distributions in CI, then call reusable Python publishing with PyPI and TestPyPI approval environments.
- Promote tested Docker staging manifests through a reusable publisher; main updates edge and stable tags update release and latest tags.
- Validate release tags against main ancestry and the package version, while preserving the v-prefixed tag for Docker metadata.
- Update CI and release workflow documentation.

Validation

- Parsed the workflow YAML and checked the selected PR and full test matrices.
- Checked release-tag and Docker metadata handoff wiring.
- Ran shell syntax checks for CI helper scripts and git diff --check.