### PR TITLE
feat: update N320 test data source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
           severity: CRITICAL
 
   docker-staging:
-    name: BuildDocker staging images
+    name: Build Docker staging images
     if: github.event_name != 'pull_request'
     needs:
       [code-quality, unit-tests, integration-tests, package-tests, docs]
@@ -406,7 +406,7 @@ jobs:
           severity: CRITICAL
 
   docker-staging-manifest:
-    name: ValidateDocker staging manifest
+    name: Validate Docker staging manifest
     if: github.event_name != 'pull_request'
     needs: docker-staging
     runs-on: ubuntu-26.04

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -239,9 +239,9 @@ PyStormTracker is distributed through `conda-forge` in addition to PyPI.
 
 **Description:** Process one-dimensional reduced Gaussian fields, such as ERA5 N320 data, using the number of longitude points on each latitude ring.
 
-**Progress:** `DataLoader` reads `GRIB_pl` ring-size metadata. Filtering and regridding use `ducc0.sht.pseudo_analysis` with per-ring `nphi`, longitude origin, and ring offsets. Synthetic tests cover metadata, filtering, and regridding paths. An optional integration path is present for real N320 data.
+**Progress:** `DataLoader` reads `GRIB_pl` ring-size metadata. Filtering and regridding use `ducc0.sht.pseudo_analysis` with per-ring `nphi`, longitude origin, and ring offsets. Synthetic tests cover metadata, filtering, and regridding paths. Integration tests download versioned N320 mean sea level pressure and relative-vorticity GRIB fixtures, then cover loading, filtering, regridding, and tracking.
 
-**Verification:** Complete and record an end-to-end run with a versioned real N320 dataset, including loading, filtering, regridding, detection, and tracking.
+**Verification:** Repository integration tests exercise an end-to-end run on the versioned N320 mean sea level pressure fixture, including loading, filtering, regridding, detection, and tracking.
 
 ### 5.17 Four-dimensional feature tracking (STACKER)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,7 +57,7 @@ Add a scheduled CI job using `uv sync --resolution lowest-direct` and the releva
 
 ### 2.4 Tiered testing — ✅ Implemented
 
-Unit tests run by default. Integration tests require `--run-integration`; slow regression cases additionally require `--run-slow`. `--run-all` disables these collection filters.
+Unit tests run by default. Integration tests require `--run-integration`; slow regression and full-duration backend-parity cases additionally require `--run-slow`. `--run-all` disables these collection filters.
 
 ## 3. Architecture
 

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 import xarray as xr
-from utils import RAW_CONTENT_URL
+from utils import RAW_CONTENT_URL, fetch_era5_msl
 
 from pystormtracker.io.data_loader import DataLoader
 
@@ -30,3 +30,18 @@ def test_dataloader_remote_autodetection(url: str, expected_engine: str) -> None
     assert loader.engine is None  # Auto-detection was used
     # Check that it was cached
     assert url in DataLoader._ds_cache
+
+
+@pytest.mark.integration
+def test_dataloader_local_zarr_archive() -> None:
+    """Open the release Zarr archive after local extraction."""
+    pytest.importorskip("zarr")
+
+    zarr_path = fetch_era5_msl(format="zarr", local=True)
+    loader = DataLoader(zarr_path)
+    ds = loader.ensure_open()
+
+    assert isinstance(ds, xr.Dataset)
+    assert "msl" in ds.data_vars
+    time_name, latitude_name, longitude_name = loader.get_coords()
+    assert {time_name, latitude_name, longitude_name} <= set(ds.coords)

--- a/tests/integration/test_reduced_gaussian.py
+++ b/tests/integration/test_reduced_gaussian.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import xarray as xr
-from utils import get_reduced_gaussian_path
+from utils import fetch_era5_msl, fetch_era5_vo850
 
 from pystormtracker.hodges.tracker import HodgesTracker
 from pystormtracker.io.data_loader import DataLoader
@@ -13,14 +13,18 @@ from pystormtracker.preprocessing.regrid import SpectralRegridder
 from pystormtracker.preprocessing.spectral import apply_sht_filter
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def n320_msl_path() -> str:
-    path = get_reduced_gaussian_path()
-    if path is None:
-        pytest.skip("Set PYSTORMTRACKER_N320_DATA to run real N320 tests")
-    if not path.exists():
-        pytest.skip(f"Configured N320 test data {path} not found")
-    return str(path)
+    """Download N320 mean sea level pressure data once per module."""
+    pytest.importorskip("cfgrib")
+    return fetch_era5_msl(resolution="n320", format="grib")
+
+
+@pytest.fixture(scope="module")
+def n320_vo_path() -> str:
+    """Download N320 relative vorticity data once per module."""
+    pytest.importorskip("cfgrib")
+    return fetch_era5_vo850(resolution="n320", format="grib")
 
 
 @pytest.mark.integration
@@ -30,6 +34,19 @@ def test_reduced_gaussian_loader(n320_msl_path: str) -> None:
 
     assert loader.is_reduced_gaussian("msl")
     pl = loader.get_reduced_grid_pl("msl")
+    assert pl is not None
+    assert len(pl) == 640
+    assert np.sum(pl) == 542080
+
+
+@pytest.mark.integration
+def test_reduced_gaussian_vo_loader(n320_vo_path: str) -> None:
+    """Verify the N320 relative-vorticity fixture exposes reduced-grid metadata."""
+    loader = DataLoader(n320_vo_path)
+    loader.ensure_open()
+
+    assert loader.is_reduced_gaussian("vo")
+    pl = loader.get_reduced_grid_pl("vo")
     assert pl is not None
     assert len(pl) == 640
     assert np.sum(pl) == 542080

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -113,7 +113,11 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             raw_params = [p for p in raw_params if p[2] is None]
 
         params = [
-            pytest.param((varname, mode, steps), id=test_id)
+            pytest.param(
+                (varname, mode, steps),
+                id=test_id,
+                marks=pytest.mark.slow if steps is None else (),
+            )
             for varname, mode, steps, test_id in raw_params
         ]
 
@@ -130,7 +134,7 @@ def config(
     varname, mode, steps = config_params
     data_path = test_data_msl if varname == "msl" else test_data_vo
 
-    # Full tests only run in CI or when --run-all is explicitly passed
+    # Full tests only run in CI or when --run-all is explicitly passed.
     is_ci = os.environ.get("GITHUB_ACTIONS")
     run_all = request.config.getoption("--run-all")
 

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -134,12 +134,15 @@ def config(
     varname, mode, steps = config_params
     data_path = test_data_msl if varname == "msl" else test_data_vo
 
-    # Full tests only run in CI or when --run-all is explicitly passed.
+    # Full tests run in CI or when --run-slow/--run-all is explicitly passed.
     is_ci = os.environ.get("GITHUB_ACTIONS")
     run_all = request.config.getoption("--run-all")
+    run_slow = request.config.getoption("--run-slow")
 
-    if steps is None and not (is_ci or run_all):
-        pytest.skip("Full integration tests only run in CI or with --run-all")
+    if steps is None and not (is_ci or run_all or run_slow):
+        pytest.skip(
+            "Full integration tests only run in CI or with --run-slow/--run-all"
+        )
 
     return data_path, varname, mode, steps
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import utils
 from utils import (
+    DATA_RELEASE_VERSION,
     RAW_CONTENT_URL,
     fetch_era5_msl,
     fetch_era5_uv850,
     fetch_era5_vo850,
     get_base_dir,
+    get_cached_data,
+    list_release_files,
+    parse_sha256sums,
 )
+
+
+def _configure_asset(cache: MagicMock, filename: str) -> None:
+    cache.registry = {filename: "sha256:0123456789abcdef"}
 
 
 def test_get_base_dir() -> None:
@@ -20,54 +30,181 @@ def test_get_base_dir() -> None:
     assert (base_dir / "tests").is_dir()
 
 
-@patch("utils.CACHED_DATA")
-def test_fetch_era5_msl_valid(mock_pooch: MagicMock) -> None:
-    mock_pooch.fetch.return_value = "/path/to/data.nc"
+def test_parse_sha256sums(tmp_path: Path) -> None:
+    manifest = tmp_path / "SHA256SUMS"
+    msl_checksum = "a" * 64
+    vo_checksum = "B" * 64
+    manifest.write_text(
+        "# Release data\n"
+        f"{msl_checksum}  era5_msl_2025-2026_djf_n320.grib\n"
+        f"{vo_checksum} era5_vo850_2025-2026_djf_n320.grib\n",
+        encoding="utf-8",
+    )
+
+    registry = parse_sha256sums(manifest)
+
+    assert registry == {
+        "era5_msl_2025-2026_djf_n320.grib": f"sha256:{msl_checksum}",
+        "era5_vo850_2025-2026_djf_n320.grib": f"sha256:{vo_checksum.lower()}",
+    }
+
+
+@pytest.mark.parametrize(
+    ("manifest_text", "match"),
+    [
+        ("not-a-valid-entry\n", "Invalid SHA256SUMS entry"),
+        (
+            f"{'z' * 64} era5_msl_2025-2026_djf_n320.grib\n",
+            "Invalid SHA-256 checksum",
+        ),
+        (
+            f"{'a' * 64} nested/era5_msl_2025-2026_djf_n320.grib\n",
+            "Invalid release filename",
+        ),
+        ("# no assets\n", "does not contain any data assets"),
+    ],
+)
+def test_parse_sha256sums_rejects_invalid_entries(
+    tmp_path: Path, manifest_text: str, match: str
+) -> None:
+    manifest = tmp_path / "SHA256SUMS"
+    manifest.write_text(manifest_text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=match):
+        parse_sha256sums(manifest)
+
+
+@patch("utils.pooch.create")
+@patch("utils.pooch.retrieve")
+def test_get_cached_data_loads_release_manifest(
+    mock_retrieve: MagicMock,
+    mock_create: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest = tmp_path / "SHA256SUMS"
+    checksum = "a" * 64
+    manifest.write_text(
+        f"{checksum} era5_msl_2025-2026_djf_n320.grib\n", encoding="utf-8"
+    )
+    cache = MagicMock()
+    mock_retrieve.return_value = str(manifest)
+    mock_create.return_value = cache
+    monkeypatch.setattr(utils, "CACHED_DATA", None)
+
+    assert get_cached_data() is cache
+
+    retrieve_kwargs = mock_retrieve.call_args.kwargs
+    assert retrieve_kwargs["url"] == utils.SHA256SUMS_URL
+    assert retrieve_kwargs["known_hash"] is None
+    assert retrieve_kwargs["fname"] == utils.SHA256SUMS_FILENAME
+    assert retrieve_kwargs["path"]
+    assert mock_create.call_args.kwargs["registry"] == {
+        "era5_msl_2025-2026_djf_n320.grib": f"sha256:{checksum}"
+    }
+
+
+@patch("utils.get_cached_data")
+def test_list_release_files(mock_get_cached_data: MagicMock) -> None:
+    mock_get_cached_data.return_value.registry = {
+        "z.nc": "sha256:1",
+        "a.grib": "sha256:2",
+    }
+
+    assert list_release_files() == ("a.grib", "z.nc")
+
+
+@patch("utils.get_cached_data")
+def test_fetch_era5_msl_valid(mock_get_cached_data: MagicMock) -> None:
+    filename = "era5_msl_2025-2026_djf_2.5x2.5.nc"
+    cache = mock_get_cached_data.return_value
+    _configure_asset(cache, filename)
+    cache.fetch.return_value = "/path/to/data.nc"
+
     path = fetch_era5_msl(resolution="2.5x2.5", season="djf", format="nc")
+
     assert path == "/path/to/data.nc"
-    mock_pooch.fetch.assert_called_once_with("era5_msl_2025-2026_djf_2.5x2.5.nc")
+    cache.fetch.assert_called_once_with(filename)
 
 
-@patch("utils.CACHED_DATA")
-def test_fetch_era5_msl_grib(mock_pooch: MagicMock) -> None:
-    mock_pooch.fetch.return_value = "/path/to/data.grib"
-    path = fetch_era5_msl(resolution="0.25x0.25", season="djf", format="grib")
+@patch("utils.get_cached_data")
+def test_fetch_era5_msl_n320_grib(mock_get_cached_data: MagicMock) -> None:
+    filename = "era5_msl_2025-2026_djf_n320.grib"
+    cache = mock_get_cached_data.return_value
+    _configure_asset(cache, filename)
+    cache.fetch.return_value = "/path/to/data.grib"
+
+    path = fetch_era5_msl(resolution="n320", format="grib")
+
     assert path == "/path/to/data.grib"
-    mock_pooch.fetch.assert_called_once_with("era5_msl_2025-2026_djf_0.25x0.25.grib")
+    cache.fetch.assert_called_once_with(filename)
 
 
-def test_fetch_era5_zarr() -> None:
-    """Test that fetching zarr format returns a URL."""
+def test_fetch_era5_zarr_remote() -> None:
     url = fetch_era5_msl(resolution="2.5x2.5", format="zarr")
-    expected_url = f"{RAW_CONTENT_URL}era5_msl_2025-2026_djf_2.5x2.5.zarr"
-    assert url == expected_url
+
+    assert url == f"{RAW_CONTENT_URL}era5_msl_2025-2026_djf_2.5x2.5.zarr"
 
 
-def test_fetch_era5_msl_invalid_res() -> None:
-    with pytest.raises(ValueError, match="Resolution must be either"):
+@patch("utils.get_cached_data")
+def test_fetch_era5_zarr_local(mock_get_cached_data: MagicMock) -> None:
+    archive_filename = "era5_msl_2025-2026_djf_2.5x2.5.zarr.tar.gz"
+    cache = mock_get_cached_data.return_value
+    _configure_asset(cache, archive_filename)
+    cache.fetch.return_value = [
+        "/cache/archive.untar/era5_msl.zarr/zarr.json",
+        "/cache/archive.untar/era5_msl.zarr/msl/c/0/0",
+    ]
+
+    path = fetch_era5_msl(resolution="2.5x2.5", format="zarr", local=True)
+
+    assert path == "/cache/archive.untar/era5_msl.zarr"
+    call_args = cache.fetch.call_args
+    assert call_args.args == (archive_filename,)
+    assert call_args.kwargs["processor"].__class__.__name__ == "Untar"
+
+
+@patch("utils.get_cached_data")
+def test_fetch_era5_vo850_valid(mock_get_cached_data: MagicMock) -> None:
+    filename = "era5_vo850_2025-2026_djf_2.5x2.5.nc"
+    cache = mock_get_cached_data.return_value
+    _configure_asset(cache, filename)
+    cache.fetch.return_value = "/path/to/vo850.nc"
+
+    path = fetch_era5_vo850(resolution="2.5x2.5", season="djf", format="nc")
+
+    assert path == "/path/to/vo850.nc"
+    cache.fetch.assert_called_once_with(filename)
+
+
+def test_fetch_era5_uv850_zarr_remote() -> None:
+    url = fetch_era5_uv850(resolution="2.5x2.5", format="zarr")
+
+    assert url == f"{RAW_CONTENT_URL}era5_uv850_2025-2026_djf_2.5x2.5.zarr"
+
+
+@patch("utils.get_cached_data")
+def test_fetch_era5_invalid_resolution(mock_get_cached_data: MagicMock) -> None:
+    mock_get_cached_data.return_value.registry = {}
+
+    with pytest.raises(ValueError, match="not available in release"):
         fetch_era5_msl(resolution="invalid")
 
 
-def test_fetch_era5_msl_invalid_season() -> None:
+def test_fetch_era5_invalid_season() -> None:
     with pytest.raises(ValueError, match="Season 'mam' not available"):
         fetch_era5_msl(season="mam")
 
 
-def test_fetch_era5_msl_invalid_format() -> None:
+def test_fetch_era5_invalid_format() -> None:
     with pytest.raises(ValueError, match="Format must be"):
         fetch_era5_msl(format="txt")
 
 
-@patch("utils.CACHED_DATA")
-def test_fetch_era5_vo850_valid(mock_pooch: MagicMock) -> None:
-    mock_pooch.fetch.return_value = "/path/to/vo850.nc"
-    path = fetch_era5_vo850(resolution="2.5x2.5", season="djf", format="nc")
-    assert path == "/path/to/vo850.nc"
-    mock_pooch.fetch.assert_called_once_with("era5_vo850_2025-2026_djf_2.5x2.5.nc")
+def test_fetch_era5_local_requires_zarr() -> None:
+    with pytest.raises(ValueError, match="only supported when format='zarr'"):
+        fetch_era5_msl(local=True)
 
 
-def test_fetch_era5_uv850_valid() -> None:
-    """Test that fetching uv850 zarr format returns a URL."""
-    url = fetch_era5_uv850(resolution="2.5x2.5", season="djf", format="zarr")
-    expected_url = f"{RAW_CONTENT_URL}era5_uv850_2025-2026_djf_2.5x2.5.zarr"
-    assert url == expected_url
+def test_data_release_version() -> None:
+    assert DATA_RELEASE_VERSION == "v0.1.4-data"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,6 +8,7 @@ import utils
 from utils import (
     DATA_RELEASE_VERSION,
     RAW_CONTENT_URL,
+    SHA256SUMS_HASH,
     fetch_era5_msl,
     fetch_era5_uv850,
     fetch_era5_vo850,
@@ -96,7 +97,7 @@ def test_get_cached_data_loads_release_manifest(
 
     retrieve_kwargs = mock_retrieve.call_args.kwargs
     assert retrieve_kwargs["url"] == utils.SHA256SUMS_URL
-    assert retrieve_kwargs["known_hash"] is None
+    assert retrieve_kwargs["known_hash"] == SHA256SUMS_HASH
     assert retrieve_kwargs["fname"] == utils.SHA256SUMS_FILENAME
     assert retrieve_kwargs["path"]
     assert mock_create.call_args.kwargs["registry"] == {
@@ -140,7 +141,11 @@ def test_fetch_era5_msl_n320_grib(mock_get_cached_data: MagicMock) -> None:
     cache.fetch.assert_called_once_with(filename)
 
 
-def test_fetch_era5_zarr_remote() -> None:
+@patch("utils.get_cached_data")
+def test_fetch_era5_zarr_remote(mock_get_cached_data: MagicMock) -> None:
+    archive_filename = "era5_msl_2025-2026_djf_2.5x2.5.zarr.tar.gz"
+    _configure_asset(mock_get_cached_data.return_value, archive_filename)
+
     url = fetch_era5_msl(resolution="2.5x2.5", format="zarr")
 
     assert url == f"{RAW_CONTENT_URL}era5_msl_2025-2026_djf_2.5x2.5.zarr"
@@ -177,10 +182,25 @@ def test_fetch_era5_vo850_valid(mock_get_cached_data: MagicMock) -> None:
     cache.fetch.assert_called_once_with(filename)
 
 
-def test_fetch_era5_uv850_zarr_remote() -> None:
-    url = fetch_era5_uv850(resolution="2.5x2.5", format="zarr")
+@pytest.mark.parametrize("resolution", ["invalid", "n320"])
+@patch("utils.get_cached_data")
+def test_fetch_era5_zarr_remote_requires_release_asset(
+    mock_get_cached_data: MagicMock, resolution: str
+) -> None:
+    mock_get_cached_data.return_value.registry = {}
 
-    assert url == f"{RAW_CONTENT_URL}era5_uv850_2025-2026_djf_2.5x2.5.zarr"
+    with pytest.raises(ValueError, match="not available in release"):
+        fetch_era5_msl(resolution=resolution, format="zarr")
+
+
+@patch("utils.get_cached_data")
+def test_fetch_era5_uv850_zarr_remote_requires_release_asset(
+    mock_get_cached_data: MagicMock,
+) -> None:
+    mock_get_cached_data.return_value.registry = {}
+
+    with pytest.raises(ValueError, match="not available in release"):
+        fetch_era5_uv850(resolution="2.5x2.5", format="zarr")
 
 
 @patch("utils.get_cached_data")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
+from typing import cast
 
 import pooch  # type: ignore[import-untyped]
 
-DATA_RELEASE_VERSION = "v0.1.3-data"
+DATA_RELEASE_VERSION = "v0.1.4-data"
 RELEASE_URL = f"https://github.com/mwyau/PyStormTracker-Data/releases/download/{DATA_RELEASE_VERSION}/"
 RAW_CONTENT_URL = f"https://raw.githubusercontent.com/mwyau/PyStormTracker-Data/{DATA_RELEASE_VERSION}/"
+SHA256SUMS_URL = f"{RELEASE_URL}SHA256SUMS"
+SHA256SUMS_FILENAME = f"{DATA_RELEASE_VERSION}-SHA256SUMS"
 
 
 def get_base_dir() -> Path:
@@ -15,124 +17,200 @@ def get_base_dir() -> Path:
     return Path(__file__).parent.parent.absolute()
 
 
-# Define a central repository of data files
-CACHED_DATA = pooch.create(
-    path=pooch.os_cache("pystormtracker"),
-    base_url=RELEASE_URL,
-    registry={
-        "era5_msl_2025-2026_djf_0.25x0.25.nc": (
-            "sha256:a1847093356472303585eb9acdbfb8c993795a2e643e80d5f7cc803d0919216d"
-        ),
-        "era5_msl_2025-2026_djf_2.5x2.5.nc": (
-            "sha256:19477e18e4239b9f8ea5a7b7a56c2f3790fbc661bbff1a949e59ebda1a61fc40"
-        ),
-        "era5_msl_2025-2026_djf_2.5x2.5.grib": (
-            "sha256:74213e8fb335e4ad17d2c07ae4719427bad788e9ac0e00637fd5523a82362e38"
-        ),
-        "era5_vo850_2025-2026_djf_0.25x0.25.nc": (
-            "sha256:907f1d94bebc87a83207d36cd395ce2051829d3a2669ab64befc1243ddb9058d"
-        ),
-        "era5_vo850_2025-2026_djf_2.5x2.5.nc": (
-            "sha256:46ce78cd3b065d3777c2d628cdc2311d68a9fcb4d3a3b9948db7c7376ae7a6aa"
-        ),
-        "era5_vo850_2025-2026_djf_2.5x2.5.grib": (
-            "sha256:9b92f82bb252fbafa90b507df75faa61721062cd70915b8f42da8d803a5a86d7"
-        ),
-        "era5_uv850_2025-2026_djf_0.25x0.25.nc": (
-            "sha256:0e35d002edc8bdbdbe9bc5f965db76dcf983d97b613ba4e217d0a4f5d84c3e51"
-        ),
-        "era5_uv850_2025-2026_djf_2.5x2.5.nc": (
-            "sha256:43cbc346a52c5230ac34eb22c7a640800fbffad40da4058686c8042a76bc5965"
-        ),
-    },
-)
+CACHED_DATA: pooch.Pooch | None = None
+
+
+def parse_sha256sums(path: Path) -> dict[str, str]:
+    """Parse a release checksum manifest into a Pooch registry."""
+    registry: dict[str, str] = {}
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line_number, raw_line in enumerate(lines, 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid SHA256SUMS entry on line {line_number}: {raw_line!r}"
+            )
+
+        checksum, filename = parts
+        is_sha256 = len(checksum) == 64 and all(
+            char in "0123456789abcdef" for char in checksum.lower()
+        )
+        if not is_sha256:
+            raise ValueError(
+                f"Invalid SHA-256 checksum on line {line_number}: {checksum!r}"
+            )
+        if Path(filename).name != filename:
+            raise ValueError(
+                f"Invalid release filename on line {line_number}: {filename!r}"
+            )
+        registry[filename] = f"sha256:{checksum.lower()}"
+
+    if not registry:
+        raise ValueError("SHA256SUMS does not contain any data assets")
+    return registry
+
+
+def get_cached_data() -> pooch.Pooch:
+    """Return the cache backed by the current release checksum manifest."""
+    global CACHED_DATA
+
+    if CACHED_DATA is None:
+        manifest_path = Path(
+            pooch.retrieve(
+                url=SHA256SUMS_URL,
+                known_hash=None,
+                fname=SHA256SUMS_FILENAME,
+                path=pooch.os_cache("pystormtracker"),
+            )
+        )
+        CACHED_DATA = pooch.create(
+            path=pooch.os_cache("pystormtracker"),
+            base_url=RELEASE_URL,
+            registry=parse_sha256sums(manifest_path),
+        )
+    return CACHED_DATA
+
+
+def list_release_files() -> tuple[str, ...]:
+    """Return the data asset filenames published by the current release."""
+    return tuple(sorted(get_cached_data().registry))
+
+
+def fetch_release_file(filename: str) -> str:
+    """Fetch a checksum-verified data asset from the current release."""
+    return str(get_cached_data().fetch(filename))
+
+
+def _release_filename(
+    variable: str,
+    resolution: str,
+    season: str,
+    format: str,
+) -> str:
+    suffix = ".zarr.tar.gz" if format == "zarr" else f".{format}"
+    return f"era5_{variable}_2025-2026_{season}_{resolution}{suffix}"
+
+
+def _validate_release_asset(filename: str) -> None:
+    if filename not in get_cached_data().registry:
+        raise ValueError(
+            f"Data asset '{filename}' is not available in release "
+            f"{DATA_RELEASE_VERSION}"
+        )
+
+
+def _fetch_local_zarr(filename: str) -> str:
+    extracted_files = cast(
+        list[str],
+        get_cached_data().fetch(filename, processor=pooch.Untar()),
+    )
+    stores = {
+        parent
+        for extracted_file in extracted_files
+        for parent in Path(extracted_file).parents
+        if parent.name.endswith(".zarr")
+    }
+    if len(stores) != 1:
+        raise ValueError(
+            f"Expected one Zarr store in archive '{filename}', found {len(stores)}"
+        )
+    return str(next(iter(stores)))
+
+
+def _fetch_era5(
+    variable: str,
+    resolution: str,
+    season: str,
+    format: str,
+    local: bool,
+) -> str:
+    if season != "djf":
+        raise ValueError(f"Season '{season}' not available. Options: 'djf'")
+    if format not in ("nc", "grib", "zarr"):
+        raise ValueError("Format must be 'nc', 'grib', or 'zarr'")
+    if local and format != "zarr":
+        raise ValueError("local=True is only supported when format='zarr'")
+
+    if format == "zarr":
+        filename = _release_filename(variable, resolution, season, format)
+        if not local:
+            return RAW_CONTENT_URL + filename.removesuffix(".tar.gz")
+        _validate_release_asset(filename)
+        return _fetch_local_zarr(filename)
+
+    filename = _release_filename(variable, resolution, season, format)
+    _validate_release_asset(filename)
+    return fetch_release_file(filename)
 
 
 def fetch_era5_msl(
-    resolution: str = "2.5x2.5", season: str = "djf", format: str = "nc"
+    resolution: str = "2.5x2.5",
+    season: str = "djf",
+    format: str = "nc",
+    local: bool = False,
 ) -> str:
     """
     Fetches the ERA5 mean sea level pressure sample dataset.
     Downloads the data on the first call and returns the path to the cached local file.
 
     Args:
-        resolution (str): Spatial resolution of the dataset.
-            Options: "2.5x2.5" or "0.25x0.25".
+        resolution (str): Spatial resolution published by the data release.
         season (str): Season of the dataset. Currently only "djf" is available.
         format (str): File format. Options: "nc" (default), "grib", or "zarr".
+        local (bool): Extract a local Zarr store when ``format="zarr"``.
 
     Returns:
-        str: Absolute path to the downloaded local file or URL for Zarr.
+        str: Absolute path to the downloaded local file, local Zarr store, or URL.
     """
-    if resolution not in ["2.5x2.5", "0.25x0.25"]:
-        raise ValueError("Resolution must be either '2.5x2.5' or '0.25x0.25'")
-    if season not in ["djf"]:
-        raise ValueError(f"Season '{season}' not available. Options: 'djf'")
-    if format not in ["nc", "grib", "zarr"]:
-        raise ValueError("Format must be 'nc', 'grib', or 'zarr'")
-
-    fname = f"era5_msl_2025-2026_{season}_{resolution}.{format}"
-    if format == "zarr":
-        return RAW_CONTENT_URL + fname
-    return str(CACHED_DATA.fetch(fname))
+    return _fetch_era5("msl", resolution, season, format, local)
 
 
 def fetch_era5_vo850(
-    resolution: str = "2.5x2.5", season: str = "djf", format: str = "nc"
+    resolution: str = "2.5x2.5",
+    season: str = "djf",
+    format: str = "nc",
+    local: bool = False,
 ) -> str:
     """
     Fetches the ERA5 850hPa relative vorticity sample dataset.
     Downloads the data on the first call and returns the path to the cached local file.
 
     Args:
-        resolution (str): Spatial resolution of the dataset.
-            Options: "2.5x2.5" or "0.25x0.25".
+        resolution (str): Spatial resolution published by the data release.
         season (str): Season of the dataset. Currently only "djf" is available.
         format (str): File format. Options: "nc" (default), "grib", or "zarr".
+        local (bool): Extract a local Zarr store when ``format="zarr"``.
 
     Returns:
-        str: Absolute path to the downloaded local file or URL for Zarr.
+        str: Absolute path to the downloaded local file, local Zarr store, or URL.
     """
-    if resolution not in ["2.5x2.5", "0.25x0.25"]:
-        raise ValueError("Resolution must be either '2.5x2.5' or '0.25x0.25'")
-    if season not in ["djf"]:
-        raise ValueError(f"Season '{season}' not available. Options: 'djf'")
-    if format not in ["nc", "grib", "zarr"]:
-        raise ValueError("Format must be 'nc', 'grib', or 'zarr'")
-
-    fname = f"era5_vo850_2025-2026_{season}_{resolution}.{format}"
-    if format == "zarr":
-        return RAW_CONTENT_URL + fname
-    return str(CACHED_DATA.fetch(fname))
+    return _fetch_era5("vo850", resolution, season, format, local)
 
 
 def fetch_era5_uv850(
-    resolution: str = "2.5x2.5", season: str = "djf", format: str = "nc"
+    resolution: str = "2.5x2.5",
+    season: str = "djf",
+    format: str = "nc",
+    local: bool = False,
 ) -> str:
     """
     Fetches the ERA5 850hPa u- and v-component of wind sample dataset.
     Downloads the data on the first call and returns the path to the cached local file.
 
     Args:
-        resolution (str): Spatial resolution of the dataset.
-            Options: "2.5x2.5" or "0.25x0.25".
+        resolution (str): Spatial resolution published by the data release.
         season (str): Season of the dataset. Currently only "djf" is available.
-        format (str): File format. Options: "nc" (default) or "zarr".
+        format (str): File format. Options: "nc", "grib", or "zarr".
+        local (bool): Extract a local Zarr store when ``format="zarr"``.
 
     Returns:
-        str: Absolute path to the downloaded local file or URL for Zarr.
+        str: Absolute path to the downloaded local file, local Zarr store, or URL.
     """
-    if resolution not in ["2.5x2.5", "0.25x0.25"]:
-        raise ValueError("Resolution must be either '2.5x2.5' or '0.25x0.25'")
-    if season not in ["djf"]:
-        raise ValueError(f"Season '{season}' not available. Options: 'djf'")
-    if format not in ["nc", "zarr"]:  # UV data has no GRIB for now
-        raise ValueError("Format must be 'nc' or 'zarr'")
-
-    fname = f"era5_uv850_2025-2026_{season}_{resolution}.{format}"
-    if format == "zarr":
-        return RAW_CONTENT_URL + fname
-    return str(CACHED_DATA.fetch(fname))
+    return _fetch_era5("uv850", resolution, season, format, local)
 
 
 # --- Local Integration Test Data Helpers ---
@@ -173,11 +251,3 @@ def get_legacy_track_path(var: str = "msl") -> Path:
     if var == "vo":
         return TRACKS_TEST_DIR / "era5_vo_2025-2026_djf_2.5x2.5_1e-4_v0.0.2_imilast.txt"
     raise ValueError(f"Unknown legacy variable: {var}")
-
-
-def get_reduced_gaussian_path() -> Path | None:
-    """Return the optional real N320 fixture configured by the environment."""
-    configured = os.environ.get("PYSTORMTRACKER_N320_DATA")
-    if not configured:
-        return None
-    return Path(configured).expanduser().resolve()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,9 @@ RELEASE_URL = f"https://github.com/mwyau/PyStormTracker-Data/releases/download/{
 RAW_CONTENT_URL = f"https://raw.githubusercontent.com/mwyau/PyStormTracker-Data/{DATA_RELEASE_VERSION}/"
 SHA256SUMS_URL = f"{RELEASE_URL}SHA256SUMS"
 SHA256SUMS_FILENAME = f"{DATA_RELEASE_VERSION}-SHA256SUMS"
+SHA256SUMS_HASH = (
+    "sha256:4f221867b111ec5411c58859da825b13111f9aab8a492a50172cad45fddb3ad9"
+)
 
 
 def get_base_dir() -> Path:
@@ -62,7 +65,7 @@ def get_cached_data() -> pooch.Pooch:
         manifest_path = Path(
             pooch.retrieve(
                 url=SHA256SUMS_URL,
-                known_hash=None,
+                known_hash=SHA256SUMS_HASH,
                 fname=SHA256SUMS_FILENAME,
                 path=pooch.os_cache("pystormtracker"),
             )
@@ -137,9 +140,9 @@ def _fetch_era5(
 
     if format == "zarr":
         filename = _release_filename(variable, resolution, season, format)
+        _validate_release_asset(filename)
         if not local:
             return RAW_CONTENT_URL + filename.removesuffix(".tar.gz")
-        _validate_release_asset(filename)
         return _fetch_local_zarr(filename)
 
     filename = _release_filename(variable, resolution, season, format)


### PR DESCRIPTION
## Summary
- Build the test-data cache registry from the v0.1.4 release `SHA256SUMS` manifest and expose lazy generic asset fetching.
- Fetch N320 mean-sea-level-pressure and vorticity GRIB fixtures automatically in integration tests.
- Add verified local Zarr archive extraction via `format="zarr", local=True` and cover opening the extracted store.
- Refresh the reduced-Gaussian roadmap status, CI job labels, and the mypy override list.

## Why
The previous hard-coded v0.1.3 registry could not discover the new release assets, leaving real N320 coverage dependent on a manually configured local path.

## Validation
- `uv run --no-sync pytest -q tests/unit/test_utils.py tests/unit/test_track_cli.py`
- `uv run --no-sync pytest -q tests/integration/test_reduced_gaussian.py tests/integration/test_io.py --run-integration`
- `uv run --no-sync ruff check tests/utils.py tests/unit/test_utils.py tests/integration/test_reduced_gaussian.py tests/integration/test_io.py`
- `uv run --no-sync ruff format --check tests/utils.py tests/unit/test_utils.py tests/integration/test_reduced_gaussian.py tests/integration/test_io.py`
- `uv run --no-sync mypy tests/utils.py tests/unit/test_utils.py tests/integration/test_reduced_gaussian.py tests/integration/test_io.py`