### PR TITLE
build: fix Docker arm64 ducc0 compiler flags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Test container import
         run: docker run --rm --entrypoint python "${{ steps.test-image.outputs.reference }}" -c 'import pystormtracker; print("container import success")'
 
-      - name: Self-check container GRIB support
+      - name: Test container GRIB support
         run: docker run --rm --entrypoint python "${{ steps.test-image.outputs.reference }}" -m cfgrib selfcheck
 
       - name: Scan critical vulnerabilities

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY --from=uv /uv /uvx /bin/
 
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
+    CXX=g++ \
+    LDSHARED="g++ -shared" \
     uv sync --frozen --no-dev --no-install-workspace --extra grib --extra netcdf4 --no-editable
 
 COPY src/ ./src/


### PR DESCRIPTION
## Summary

Fix the ARM64 Docker image failing to import `ducc0` on Linux.

The Linux ARM64 build compiles `ducc0` from source because no compatible PyPI wheel is available for CPython 3.14 on Linux AArch64. The generated extension was linked without the required C++ runtime dependencies.

## Failure

Running the ARM64 image failed with:

```text
ImportError: ducc0.cpython-314-aarch64-linux-gnu.so:
undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE
```

[Failed CI Docker Build](https://github.com/mwyau/PyStormTracker/actions/runs/30721518261/job/91425998831#step:8:16)

Installing `libstdc++6` in the runtime image exposed a second unresolved symbol:

```text
undefined symbol: _ZGVnN2v_exp
```

Inspection of the extension showed that it declared only:

```text
libgcc_s.so.1
libc.so.6
```

It did not declare the required C++ and math runtime dependencies.

## Fix

Use the C++ linker when building Python extension modules on ARM64:

```dockerfile
CXX=g++ LDSHARED="g++ -shared" uv sync ...
```

`g++ -shared` links the extension as a shared object and adds the required C++ and system runtime libraries in the correct linker order.

[Successful CI Docker Build](https://github.com/mwyau/PyStormTracker/actions/runs/30723724684/job/91431603704#step:6:287)

## Validation

Verified on the native GitHub-hosted `ubuntu-26.04-arm` runner.

The ARM64 Docker image now successfully runs:

```bash
docker run --rm <image> --help
```

and:

```bash
docker run --rm --entrypoint python <image> \
  -c "import ducc0; print(ducc0.__file__)"
```

The AMD64 Docker build remains unchanged.
