### PR TITLE
ci: ensure all code quality steps run and simplify docker tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,14 @@ jobs:
           version-file: uv.lock
 
       - name: Ruff format
+        if: ${{ !cancelled() }}
         uses: astral-sh/ruff-action@v4.1.0
         with:
           args: format --check
           version-file: uv.lock
 
       - name: Set up uv
+        if: ${{ !cancelled() }}
         uses: astral-sh/setup-uv@v9.0.0
         with:
           version: ${{ env.UV_VERSION }}
@@ -110,9 +112,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install type-checking environment
+        if: ${{ !cancelled() }}
         run: uv sync --frozen --all-extras
 
       - name: Mypy
+        if: ${{ !cancelled() }}
         run: uv run --no-sync mypy .
 
   unit-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       unit_matrix: ${{ steps.select.outputs.unit_matrix }}
       integration_matrix: ${{ steps.select.outputs.integration_matrix }}
+      uv_version: ${{ env.UV_VERSION }}
     steps:
       - name: Select representative or full matrix
         id: select
@@ -310,12 +311,12 @@ jobs:
     name: Build and test Docker images
     if: github.event_name != 'workflow_dispatch'
     needs:
-      [code-quality, unit-tests, integration-tests, package-tests, docs]
+      [select-test-matrix, code-quality, unit-tests, integration-tests, package-tests, docs]
     uses: ./.github/workflows/docker-build.yml
     with:
       push_images: ${{ github.event_name != 'pull_request' }}
       ref: ${{ github.sha }}
-      uv_version: '0.12.1'
+      uv_version: ${{ needs.select-test-matrix.outputs.uv_version }}
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ github.event_name != 'pull_request' && secrets.DOCKER_HUB_ACCESS_TOKEN || '' }}
 
@@ -378,7 +379,6 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       source_tag: ${{ needs.docker-build.outputs.source_tag }}
-      source_sha: ${{ needs.docker-build.outputs.source_sha }}
       target: edge
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -396,7 +396,6 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     with:
       source_tag: ${{ needs.docker-build.outputs.source_tag }}
-      source_sha: ${{ needs.docker-build.outputs.source_sha }}
       target: release
       version: ${{ needs.release_tag.outputs.release_tag }}
     secrets:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,11 +21,8 @@ on:
       DOCKER_HUB_ACCESS_TOKEN:
         required: false
     outputs:
-      source_sha:
-        description: Full commit SHA represented by the test image
-        value: ${{ jobs.docker-manifest.outputs.source_sha }}
       source_tag:
-        description: Tested private image tag
+        description: Tested private image tag, for example 1a2b3c4
         value: ${{ jobs.docker-manifest.outputs.source_tag }}
 
   workflow_dispatch:
@@ -73,9 +70,9 @@ jobs:
           set -euo pipefail
           SOURCE_SHA="$(git rev-parse HEAD)"
           echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
-          echo "source_tag=sha-${SOURCE_SHA:0:7}" >> "$GITHUB_OUTPUT"
+          echo "source_tag=${SOURCE_SHA:0:7}" >> "$GITHUB_OUTPUT"
 
-      - name: Select local or test-image platforms
+      - name: Select build platforms
         id: select
         env:
           PUSH_IMAGES: ${{ github.event_name == 'workflow_dispatch' || inputs.push_images }}
@@ -124,18 +121,8 @@ jobs:
         id: image
         env:
           ARCH: ${{ matrix.arch }}
-          PUSH_IMAGES: ${{ needs.select-platforms.outputs.push_images }}
           SOURCE_TAG: ${{ needs.select-platforms.outputs.source_tag }}
-        run: |
-          set -euo pipefail
-
-          if [[ "$PUSH_IMAGES" == "true" ]]; then
-            IMAGE="$TEST_IMAGE:${SOURCE_TAG}-${ARCH}"
-          else
-            IMAGE="local/pystormtracker:${SOURCE_TAG}-${ARCH}"
-          fi
-
-          echo "tag=$IMAGE" >> "$GITHUB_OUTPUT"
+        run: echo "tag=$TEST_IMAGE:${SOURCE_TAG}-${ARCH}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Docker Hub test repository
         if: needs.select-platforms.outputs.push_images == 'true'
@@ -205,7 +192,6 @@ jobs:
     runs-on: ubuntu-26.04
     timeout-minutes: 15
     outputs:
-      source_sha: ${{ needs.select-platforms.outputs.source_sha }}
       source_tag: ${{ needs.select-platforms.outputs.source_tag }}
     steps:
       - uses: docker/setup-buildx-action@v4.2.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,10 +7,6 @@ on:
         description: Tested private image tag
         required: true
         type: string
-      source_sha:
-        description: Full commit SHA represented by the test image
-        required: true
-        type: string
       target:
         description: "Promotion target: private, edge, or release"
         required: true
@@ -29,11 +25,7 @@ on:
   workflow_dispatch:
     inputs:
       source_tag:
-        description: Tested private image tag, for example sha-1a2b3c4
-        required: true
-        type: string
-      source_sha:
-        description: Full 40-character commit SHA
+        description: Tested private image tag, for example 1a2b3c4
         required: true
         type: string
       target:
@@ -58,6 +50,7 @@ permissions:
   attestations: write
 
 env:
+  SOURCE_IMAGE: docker.io/${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}:${{ inputs.source_tag }}
   PRIVATE_DOCKER_IMAGE: docker.io/${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
   PUBLIC_DOCKER_IMAGE: docker.io/${{ vars.DOCKER_ORG_NAME }}/${{ vars.DOCKER_IMAGE_NAME }}
   PRIVATE_GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ vars.DOCKER_IMAGE_NAME }}
@@ -85,13 +78,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
 
-      - name: Resolve seven-character SHA
-        id: sha
-        uses: docker/metadata-action@v6.2.0
-        with:
-          images: ${{ env.PRIVATE_DOCKER_IMAGE }}
-          tags: type=match,value=${{ inputs.source_sha }},pattern=^([0-9a-f]{7})[0-9a-f]{33}$,group=1
-
       - name: Resolve release version
         id: release
         if: inputs.target == 'release'
@@ -108,21 +94,15 @@ jobs:
           images: ${{ env.PUBLIC_DOCKER_IMAGE }}
           tags: type=match,value=${{ inputs.version }},pattern=^v([0-9]+\.[0-9]+)\.[0-9]+$,group=1
 
-      - name: Publish owner SHA tag to Docker Hub
-        run: docker buildx imagetools create --tag "${PRIVATE_DOCKER_IMAGE}:${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
-
-      - name: Publish owner SHA tag to GHCR
-        run: docker buildx imagetools create --tag "${PRIVATE_GHCR_IMAGE}:${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
-
       - name: Publish owner prefixed SHA tag to Docker Hub
-        run: docker buildx imagetools create --tag "${PRIVATE_DOCKER_IMAGE}:sha-${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+        run: docker buildx imagetools create --tag "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}" "$SOURCE_IMAGE"
 
       - name: Publish owner prefixed SHA tag to GHCR
-        run: docker buildx imagetools create --tag "${PRIVATE_GHCR_IMAGE}:sha-${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+        run: docker buildx imagetools create --tag "${PRIVATE_GHCR_IMAGE}:${{ inputs.source_tag }}" "$SOURCE_IMAGE"
 
       - name: Publish edge to Docker Hub
         if: inputs.target == 'edge'
-        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:edge" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:edge" "$SOURCE_IMAGE"
 
       - name: Publish edge to GHCR
         if: inputs.target == 'edge'
@@ -130,23 +110,23 @@ jobs:
 
       - name: Publish public prefixed SHA tag to Docker Hub
         if: inputs.target == 'edge' || inputs.target == 'release'
-        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:sha-${{ steps.sha.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ inputs.source_tag }}" "$SOURCE_IMAGE"
 
       - name: Publish public prefixed SHA tag to GHCR
         if: inputs.target == 'edge' || inputs.target == 'release'
-        run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:sha-${{ steps.sha.outputs.version }}" "${PUBLIC_DOCKER_IMAGE}:sha-${{ steps.sha.outputs.version }}"
+        run: docker buildx imagetools create --tag "${PUBLIC_GHCR_IMAGE}:${{ inputs.source_tag }}" "$SOURCE_IMAGE"
 
       - name: Publish release version to Docker Hub
         if: inputs.target == 'release'
-        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ steps.release.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ steps.release.outputs.version }}" "$SOURCE_IMAGE"
 
       - name: Publish release series to Docker Hub
         if: inputs.target == 'release'
-        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ steps.series.outputs.version }}" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:${{ steps.series.outputs.version }}" "$SOURCE_IMAGE"
 
       - name: Publish latest to Docker Hub
         if: inputs.target == 'release'
-        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:latest" "${PRIVATE_DOCKER_IMAGE}:${{ inputs.source_tag }}"
+        run: docker buildx imagetools create --tag "${PUBLIC_DOCKER_IMAGE}:latest" "$SOURCE_IMAGE"
 
       - name: Publish release version to GHCR
         if: inputs.target == 'release'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,10 +163,10 @@ runs, it instead builds native test images on:
 - `ubuntu-26.04-arm` for `linux/arm64`.
 
 Each platform image is pushed to the private repository
-`docker.io/mwyau/pystormtracker` under a `sha-<seven-character-commit>-<architecture>`
+`docker.io/mwyau/pystormtracker` under a `<seven-character-commit>-<architecture>`
 tag. CI pulls and tests the exact pushed digest. After both platform jobs succeed,
 CI creates one private multi-platform test manifest tagged
-`sha-<seven-character-commit>`.
+`<seven-character-commit>`.
 
 Pull-request Docker builds are local and do not receive registry credentials.
 The `Docker Build` workflow also supports manual dispatch for a selected ref; it
@@ -181,9 +181,9 @@ identifies the test image. Publication applies the following tags:
 
 | Source | `mwyau/pystormtracker` | `xddd/pystormtracker` |
 | --- | --- | --- |
-| `main` | seven-character SHA, `sha-<seven-character-SHA>` | `edge`, `sha-<seven-character-SHA>` |
-| stable tag `v0.6.0` | seven-character SHA, `sha-<seven-character-SHA>` | `0.6.0`, `0.6`, `latest`, `sha-<seven-character-SHA>` |
-| manual private promotion | seven-character SHA, `sha-<seven-character-SHA>` | none |
+| `main` | seven-character SHA, `<seven-character-SHA>` | `edge`, `<seven-character-SHA>` |
+| stable tag `v0.6.0` | seven-character SHA, `<seven-character-SHA>` | `0.6.0`, `0.6`, `latest`, `<seven-character-SHA>` |
+| manual private promotion | seven-character SHA, `<seven-character-SHA>` | none |
 
 The completed Docker Hub manifests are copied to the corresponding GHCR repositories without rebuilding. Public `edge` and release manifests are attested on Docker Hub only; GHCR copies are not separately attested.
 


### PR DESCRIPTION
- **Code Quality Steps**: Added `if: ${{ !cancelled() }}` to `ci.yml` lint and type-checking steps so all checks run regardless of earlier step failures.
- **Docker Tagging & Input/Output Consolidation**:
  - Consolidated Docker test-image tag inputs and outputs to `source_tag` across `docker-build.yml`, `docker-publish.yml`, and `ci.yml`.
  - Matrix build checkouts in `docker-build.yml` use internal 40-character `source_sha` to prevent branch race conditions during builds.
  - Defined `SOURCE_IMAGE` in `docker-publish.yml` `env` to eliminate repeated image tag strings.
  - Exposed `uv_version: ${{ env.UV_VERSION }}` from `select-test-matrix` outputs and passed it to `docker-build.yml` to eliminate duplicate version strings.
  - Updated `docs/architecture.md` to reflect the 7-character commit SHA tagging structure.