### PR TITLE
build(docker): update CXX env variable in Docker build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM python:3.14-slim AS builder
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
-    UV_PYTHON_DOWNLOADS=0
+    UV_PYTHON_DOWNLOADS=0 \
+    CXX=g++
 
 WORKDIR /app
 
@@ -19,20 +20,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=uv /uv /uvx /bin/
 
 COPY pyproject.toml uv.lock ./
+
 RUN --mount=type=cache,target=/root/.cache/uv \
-    CXX=g++ \
-    LDSHARED="g++ -shared" \
-    uv sync --frozen --no-dev --no-install-workspace --extra grib --extra netcdf4 --no-editable
+    uv sync --frozen --no-dev --no-install-workspace \
+        --extra grib --extra netcdf4 --no-editable
 
 COPY src/ ./src/
 COPY README.md ./
+
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --extra grib --extra netcdf4 --no-editable
+    uv sync --frozen --no-dev \
+        --extra grib --extra netcdf4 --no-editable
 
 # --- Runtime Stage ---
 FROM python:3.14-slim
 
 WORKDIR /app
+
 RUN mkdir /data && chmod 777 /data
 
 COPY --from=builder /app/.venv /app/.venv


### PR DESCRIPTION
## Summary

<!-- What changed, and the user or developer impact. -->

- Set `CXX=g++` as an environment variable in the Docker `python:3.14-slim` builder. `LDSHARED="g++ -shared"` is not needed.

## Why

<!-- Why this change is needed. For fixes, describe the root cause. -->

- When the `CXX` environment variable is not set in the slim builder image, `scikit-build-core` is using `CXX=gcc` from the Python's `sysconfig` value:

```python
root@69208d5cd7bf:/# Inside python:3.14-slim container
$ python -c 'import sysconfig; print(sysconfig.get_config_var("CXX"))'
gcc
```

- Related upstream issue: https://github.com/mreineck/ducc/issues/54

## Validation

<!-- Commands, CI jobs, datasets, or manual checks used to verify the change. -->

- [x] [Docker Build](https://github.com/mwyau/PyStormTracker/actions/runs/30761601503) is successful.
