### PR TITLE
ci: remove empty slow integration lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
             }'
             INTEGRATION_MATRIX='{
               "include": [
-                {"os": "ubuntu-26.04", "python-version": "3.14", "slow": true},
                 {"os": "ubuntu-26.04-arm", "python-version": "3.14", "slow": false},
                 {"os": "ubuntu-24.04", "python-version": "3.14", "slow": false},
                 {"os": "windows-2025", "python-version": "3.13", "slow": false},


### PR DESCRIPTION
## Summary

- Remove the empty `slow` integration-test lane from the full CI matrix.
- Keep the existing non-slow integration coverage unchanged across the supported platforms.

## Why

The slow integration lane runs `tests/integration/` with the `slow and not data` marker selection, but there are currently no matching tests after the recent test-suite reorganization. The job therefore adds CI time and a skipped/empty lane without providing additional coverage.

Removing the matrix entry simplifies the workflow without changing test behavior or reducing active integration coverage.

## Validation

- [x] Change is limited to the unused integration-matrix entry in `.github/workflows/ci.yml`.
- [x] Dependency Review passes on the PR head.
- [ ] Full CI is running on the PR head.
