### PR TITLE
ci: compare Numba coverage modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
             UNIT_MATRIX='{
               "include": [
                 {"os": "ubuntu-26.04", "python-version": "3.12", "mode": "min-deps"},
-                {"os": "ubuntu-26.04", "python-version": "3.14", "mode": "coverage"},
+                {"os": "ubuntu-26.04", "python-version": "3.14", "mode": "coverage", "coverage_flag": "unit"},
+                {"os": "ubuntu-26.04", "python-version": "3.14", "mode": "jit-coverage", "coverage_flag": "unit-jit-coverage"},
+                {"os": "ubuntu-26.04", "python-version": "3.14", "mode": "disabled-jit-coverage", "coverage_flag": "unit-jit-disabled"},
                 {"os": "windows-2025", "python-version": "3.13", "mode": "normal"},
                 {"os": "macos-26", "python-version": "3.14", "mode": "normal"}
               ]
@@ -61,7 +63,9 @@ jobs:
                 {"os": "ubuntu-26.04", "python-version": "3.12", "mode": "normal"},
                 {"os": "ubuntu-26.04", "python-version": "3.12", "mode": "min-deps"},
                 {"os": "ubuntu-26.04", "python-version": "3.13", "mode": "normal"},
-                {"os": "ubuntu-26.04", "python-version": "3.14", "mode": "coverage"},
+                {"os": "ubuntu-26.04", "python-version": "3.14", "mode": "coverage", "coverage_flag": "unit"},
+                {"os": "ubuntu-26.04", "python-version": "3.14", "mode": "jit-coverage", "coverage_flag": "unit-jit-coverage"},
+                {"os": "ubuntu-26.04", "python-version": "3.14", "mode": "disabled-jit-coverage", "coverage_flag": "unit-jit-disabled"},
                 {"os": "ubuntu-26.04", "python-version": "3.14t", "mode": "free-threaded"},
                 {"os": "windows-2025", "python-version": "3.13", "mode": "normal"},
                 {"os": "macos-26", "python-version": "3.14", "mode": "normal"}
@@ -141,7 +145,7 @@ jobs:
         run: uv run --no-sync mypy
 
   unit-tests:
-    name: Unit tests (${{ matrix.os }}, Python ${{ matrix.python-version }}${{ matrix.mode == 'min-deps' && ', minimum dependencies' || '' }})
+    name: Unit tests (${{ matrix.os }}, Python ${{ matrix.python-version }}, ${{ matrix.mode }})
     needs: [select-test-matrix, code-quality]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
@@ -166,7 +170,7 @@ jobs:
           'C:\Program Files\Microsoft MPI\Bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install dependencies
-        if: matrix.mode == 'normal' || matrix.mode == 'coverage'
+        if: matrix.mode == 'normal' || matrix.mode == 'coverage' || matrix.mode == 'jit-coverage' || matrix.mode == 'disabled-jit-coverage'
         run: uv sync --frozen --all-extras
 
       - name: Install minimum direct dependencies
@@ -191,6 +195,18 @@ jobs:
         if: matrix.mode == 'coverage'
         run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
 
+      - name: Run unit tests with JIT coverage
+        if: matrix.mode == 'jit-coverage'
+        env:
+          NUMBA_JIT_COVERAGE: '1'
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
+
+      - name: Run unit tests with JIT disabled coverage
+        if: matrix.mode == 'disabled-jit-coverage'
+        env:
+          NUMBA_DISABLE_JIT: '1'
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
+
       - name: Verify free-threaded Python
         if: matrix.mode == 'free-threaded'
         env:
@@ -204,12 +220,12 @@ jobs:
         run: uv run --no-sync pytest -vv
 
       - name: Upload coverage
-        if: matrix.mode == 'coverage'
+        if: matrix.mode == 'coverage' || matrix.mode == 'jit-coverage' || matrix.mode == 'disabled-jit-coverage'
         uses: codecov/codecov-action@v7.0.0
         with:
           files: ./coverage.xml
           disable_search: true
-          flags: unit
+          flags: ${{ matrix.coverage_flag }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         run: uv run --no-sync mypy
 
   unit-tests:
-    name: Unit tests (${{ matrix.os }}, Python ${{ matrix.python-version }}, ${{ matrix.mode }})
+    name: Unit tests (${{ matrix.os }}, Python ${{ matrix.python-version }}${{ matrix.mode != 'normal' && format(', {0}', matrix.mode) || '' }})
     needs: [select-test-matrix, code-quality]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40


### PR DESCRIPTION
## Summary

This draft PR experimentally compares the existing unit coverage lane with the two Numba-supported coverage approaches. It adds only representative Ubuntu/Python 3.14 unit lanes and separate Codecov flags:

- `unit`: normal coverage
- `unit-jit-coverage`: `NUMBA_JIT_COVERAGE=1`
- `unit-jit-disabled`: `NUMBA_DISABLE_JIT=1`

The two Numba variables are never set together. No scientific tests or production code were changed.

## Local unit coverage

Command: `uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing`

All three runs collected 498 tests and passed. Percentages below are from coverage.py JSON summaries: line coverage is covered statements / statements; branch coverage is covered branches / branches; combined is the existing pytest-cov `Cover` measure.

| Mode | Line coverage | Branch coverage | Combined | Pytest / wall time |
| --- | ---: | ---: | ---: | ---: |
| Normal | 6024/9602 (62.74%) | 1688/3734 (45.21%) | 57.83% | 48.70s / 51.29s |
| JIT coverage, fresh `NUMBA_CACHE_DIR` | 8061/9602 (83.95%) | 1688/3734 (45.21%) | 73.10% | 56.32s / 58.53s |
| JIT disabled | 7744/9602 (80.65%) | 2549/3734 (68.26%) | 77.18% | 7.05s / 8.20s |

Compared with normal coverage, JIT coverage adds 2037 covered statements (+21.21 percentage points of line coverage) but no additional covered branch arcs in this run; disabled JIT adds 1720 covered statements (+17.91 points) and 861 covered branches (+23.06 points). Partial branches were 620 normal, 1718 JIT coverage, and 743 disabled JIT.

### Numba-heavy modules

Each cell is line / branch coverage.

| File | Normal | JIT coverage | JIT disabled |
| --- | ---: | ---: | ---: |
| `hodges/detector.py` | 34.96% / 24.62% | 86.72% / 24.62% | 81.58% / 78.72% |
| `hodges/mge.py` | 8.27% / 0.00% | 92.70% / 0.00% | 63.75% / 51.40% |
| `healpix/detector.py` | 46.77% / 20.59% | 75.00% / 20.59% | 72.58% / 62.75% |
| `refinement/bspline.py` | 32.93% / 19.67% | 96.50% / 19.67% | 85.78% / 69.67% |
| `refinement/quadratic.py` | 69.27% / 49.04% | 94.41% / 49.04% | 91.34% / 73.08% |
| `simple/detector.py` | 42.29% / 14.17% | 82.44% / 14.17% | 79.21% / 74.17% |
| `simple/linker.py` | 60.38% / 30.95% | 98.11% / 30.95% | 98.11% / 92.86% |
| `metrics/lagrangian.py` | 52.17% / 29.84% | 92.49% / 29.84% | 89.72% / 77.42% |

Normal coverage observes Python-level wrapper execution and misses most compiled Numba bodies. JIT coverage records execution of compiled Numba lines, which explains the large line-coverage increase; its branch percentage did not increase here, while partial-branch markers increased, so it should not be treated as equivalent to ordinary branch coverage. Disabled JIT runs the Numba-decorated functions through their Python fallback, allowing normal line and branch tracing, but does not measure compiled execution.

The fresh-cache JIT lane was about 7.24 seconds slower wall-clock than normal coverage on this host. Disabled JIT was not impractically slow for this unit suite and completed faster, likely because it avoided compilation; these are local test timings rather than a benchmark.

## Validation

- `uv run --no-sync prek run --all-files`
- Ruff check and format check
- Ty
- Mypy
- TrackJSON schema check
- Three local coverage runs above

Do not merge this draft until the CI and Codecov behavior has been reviewed.