### PR TITLE
test: improve coverage and scientific regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,11 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
-      - name: Install MPI on Windows
+      - name: Set up Microsoft MPI on Windows
         if: runner.os == 'Windows'
-        run: |
-          winget install -e --id Microsoft.msmpi --accept-source-agreements --accept-package-agreements
-          'C:\Program Files\Microsoft MPI\Bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        uses: mpi4py/setup-mpi@v1.4.4
+        with:
+          mpi: msmpi
 
       - name: Install dependencies
         if: matrix.mode == 'normal' || matrix.mode == 'coverage' || matrix.mode == 'jit-coverage' || matrix.mode == 'disabled-jit-coverage'
@@ -249,11 +249,11 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
-      - name: Install MPI on Windows
+      - name: Set up Microsoft MPI on Windows
         if: runner.os == 'Windows'
-        run: |
-          winget install -e --id Microsoft.msmpi --accept-source-agreements --accept-package-agreements
-          'C:\Program Files\Microsoft MPI\Bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        uses: mpi4py/setup-mpi@v1.4.4
+        with:
+          mpi: msmpi
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras
@@ -298,11 +298,11 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
-      - name: Install MPI on Windows
+      - name: Set up Microsoft MPI on Windows
         if: runner.os == 'Windows'
-        run: |
-          winget install -e --id Microsoft.msmpi --accept-source-agreements --accept-package-agreements
-          'C:\Program Files\Microsoft MPI\Bin' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        uses: mpi4py/setup-mpi@v1.4.4
+        with:
+          mpi: msmpi
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,12 @@ jobs:
             }'
             INTEGRATION_MATRIX='{
               "include": [
-                {"os": "ubuntu-26.04", "python-version": "3.14", "slow": false}
+                {"os": "ubuntu-26.04", "python-version": "3.14", "coverage": true}
               ]
             }'
             PARITY_MATRIX='{
               "include": [
-                {"os": "ubuntu-26.04", "python-version": "3.14", "slow": false}
+                {"os": "ubuntu-26.04", "python-version": "3.14", "coverage": true}
               ]
             }'
           else
@@ -73,15 +73,15 @@ jobs:
             }'
             INTEGRATION_MATRIX='{
               "include": [
-                {"os": "ubuntu-26.04-arm", "python-version": "3.14", "slow": false},
-                {"os": "ubuntu-24.04", "python-version": "3.14", "slow": false},
-                {"os": "windows-2025", "python-version": "3.13", "slow": false},
-                {"os": "macos-26", "python-version": "3.14", "slow": false}
+                {"os": "ubuntu-26.04-arm", "python-version": "3.14", "coverage": false},
+                {"os": "ubuntu-24.04", "python-version": "3.14", "coverage": true},
+                {"os": "windows-2025", "python-version": "3.13", "coverage": false},
+                {"os": "macos-26", "python-version": "3.14", "coverage": false}
               ]
             }'
             PARITY_MATRIX='{
               "include": [
-                {"os": "ubuntu-26.04", "python-version": "3.14", "slow": false}
+                {"os": "ubuntu-26.04", "python-version": "3.14", "coverage": true}
               ]
             }'
           fi
@@ -199,6 +199,7 @@ jobs:
         if: matrix.mode == 'jit-coverage'
         env:
           NUMBA_JIT_COVERAGE: '1'
+          NUMBA_CACHE_DIR: ${{ runner.temp }}/numba-coverage-cache
         run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
 
       - name: Run unit tests with JIT disabled coverage
@@ -257,16 +258,19 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras
 
+      - name: Run integration tests with coverage
+        if: matrix.coverage == true
+        env:
+          NUMBA_JIT_COVERAGE: '1'
+          NUMBA_CACHE_DIR: ${{ runner.temp }}/numba-coverage-cache
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml tests/integration/ -m "not slow and not data"
+
       - name: Run integration tests
-        if: matrix.slow == false
+        if: matrix.coverage == false
         run: uv run --no-sync pytest -vv tests/integration/ -m "not slow and not data"
 
-      - name: Run slow integration tests with coverage
-        if: matrix.slow == true
-        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml tests/integration/ -m "slow and not data"
-
       - name: Upload coverage
-        if: matrix.slow == true
+        if: matrix.coverage == true
         uses: codecov/codecov-action@v7.0.0
         with:
           files: ./coverage.xml
@@ -303,16 +307,19 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras
 
-      - name: Run non-slow parity tests
-        if: matrix.slow == false
+      - name: Run parity tests with coverage
+        if: matrix.coverage == true
+        env:
+          NUMBA_JIT_COVERAGE: '1'
+          NUMBA_CACHE_DIR: ${{ runner.temp }}/numba-coverage-cache
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml tests/parity/ -m "not slow and not data"
+
+      - name: Run parity tests
+        if: matrix.coverage == false
         run: uv run --no-sync pytest -vv tests/parity/ -m "not slow and not data"
 
-      - name: Run slow parity tests with coverage
-        if: matrix.slow == true
-        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml tests/parity/ -m "slow and not data"
-
       - name: Upload coverage
-        if: matrix.slow == true
+        if: matrix.coverage == true
         uses: codecov/codecov-action@v7.0.0
         with:
           files: ./coverage.xml

--- a/src/pystormtracker/hodges/detector.py
+++ b/src/pystormtracker/hodges/detector.py
@@ -81,7 +81,6 @@ def _label_connected_components(
     threshold: float,
     is_min: bool,
     periodic_x: bool = True,
-    vertex_connectivity: bool = True,
 ) -> tuple[NDArray[np.int32], int]:
     """Connected Component Labeling (CCL) fused with threshold evaluation.
 
@@ -99,7 +98,6 @@ def _label_connected_components(
         is_min: True for local minima (frame <= threshold),
             False for maxima (frame >= threshold).
         periodic_x: Whether the first and final columns are adjacent.
-        vertex_connectivity: True for 8-neighbor vertex, False for 4-neighbor edge.
 
     Returns:
         (labeled_mask, num_objects)
@@ -141,8 +139,6 @@ def _label_connected_components(
                     if ni < 0 or ni >= ny:
                         continue
                     for dj in range(-1, 2):
-                        if not vertex_connectivity and di != 0 and dj != 0:
-                            continue
                         nj = j + dj
                         if periodic_x:
                             nj %= nx
@@ -165,8 +161,6 @@ def _label_connected_components(
                     if ni < 0 or ni >= ny:
                         continue
                     for dj in range(-1, 2):
-                        if not vertex_connectivity and di != 0 and dj != 0:
-                            continue
                         nj = j + dj
                         if periodic_x:
                             nj %= nx
@@ -1425,8 +1419,22 @@ def detect_hodges_frame(
             threshold=intensity_threshold,
             is_min=is_min,
             periodic_x=periodic_x,
-            # TRACK production detection uses vertex/diagonal connectivity.
-            vertex_connectivity=True,
+        )
+        (
+            raw_areas,
+            fitted_areas,
+            majors,
+            minors,
+            orientations,
+        ) = _compute_object_properties(
+            frame,
+            labeled_mask,
+            num_objects,
+            lat,
+            lon,
+            threshold=intensity_threshold,
+            is_min=is_min,
+            spherical_coords=not projected_xy,
         )
         object_first_rows, object_first_columns = _find_object_first_indices(
             labeled_mask,

--- a/tests/integration/test_parallel_backends.py
+++ b/tests/integration/test_parallel_backends.py
@@ -412,6 +412,104 @@ def test_healpix_dask_matches_serial(workers: int) -> None:
 
 
 @pytest.mark.integration
+def test_healpix_quadratic_tracker_matches_serial_and_dask() -> None:
+    """A smooth spherical minimum follows the default quadratic path."""
+    n_times = 6
+    nside = 8
+    npix = 12 * nside * nside
+    target = (32.3, 179.2)
+    times = np.arange(n_times).astype("timedelta64[h]") + np.datetime64("2024-01-01")
+
+    hp_base = Healpix_Base(nside, "RING")
+    pixels = np.arange(npix, dtype=np.int64)
+    angles = hp_base.pix2ang(pixels)
+    latitudes = np.rad2deg(0.5 * np.pi - angles[:, 0])
+    longitudes = np.rad2deg(angles[:, 1]) % 360.0
+    target_latitude, target_longitude = np.deg2rad(target)
+    target_vector = np.array(
+        [
+            np.cos(target_latitude) * np.cos(target_longitude),
+            np.cos(target_latitude) * np.sin(target_longitude),
+            np.sin(target_latitude),
+        ]
+    )
+    points = np.stack(
+        (
+            np.cos(np.deg2rad(latitudes)) * np.cos(np.deg2rad(longitudes)),
+            np.cos(np.deg2rad(latitudes)) * np.sin(np.deg2rad(longitudes)),
+            np.sin(np.deg2rad(latitudes)),
+        ),
+        axis=-1,
+    )
+    values = np.tile(100000.0 + 10000.0 * (1.0 - points @ target_vector), (n_times, 1))
+    healpix_data = xr.DataArray(
+        values,
+        dims=("time", "cell"),
+        coords={"time": times},
+        name="msl",
+        attrs={"grid_type": "healpix", "nside": nside, "units": "Pa"},
+    )
+
+    tracker_serial = HealpixTracker(
+        nside=nside,
+        min_track_points=2,
+        dmax=10.0,
+        dmax_zones=np.empty((0, 5), dtype=np.float64),
+        segment_frames=4,
+        backend="serial",
+    )
+    tracker_dask = HealpixTracker(
+        nside=nside,
+        min_track_points=2,
+        dmax=10.0,
+        dmax_zones=np.empty((0, 5), dtype=np.float64),
+        segment_frames=4,
+        backend="dask",
+        workers=4,
+    )
+    assert tracker_serial.feature_refinement == "quadratic"
+    assert tracker_dask.feature_refinement == "quadratic"
+
+    serial = tracker_serial.track(
+        healpix_data,
+        "msl",
+        detection_mode="min",
+        object_threshold=102000.0,
+    )
+    dask = tracker_dask.track(
+        healpix_data,
+        "msl",
+        detection_mode="min",
+        object_threshold=102000.0,
+    )
+
+    assert len(serial) == 1
+    assert len(serial[0]) == n_times
+    grid_pixel = int(np.argmin(values[0]))
+    grid_latitude = float(latitudes[grid_pixel])
+    grid_longitude = float(longitudes[grid_pixel])
+
+    def angular_error(latitude: float, longitude: float) -> float:
+        latitude_rad, longitude_rad = np.deg2rad([latitude, longitude])
+        vector = np.array(
+            [
+                np.cos(latitude_rad) * np.cos(longitude_rad),
+                np.cos(latitude_rad) * np.sin(longitude_rad),
+                np.sin(latitude_rad),
+            ]
+        )
+        return float(np.rad2deg(np.arccos(np.clip(vector @ target_vector, -1.0, 1.0))))
+
+    refined_error = angular_error(float(serial[0].lats[0]), float(serial[0].lons[0]))
+    grid_error = angular_error(grid_latitude, grid_longitude)
+    assert refined_error < grid_error
+    assert refined_error < 0.1
+    np.testing.assert_allclose(serial[0].lats, target[0], atol=0.1, rtol=0.0)
+    np.testing.assert_allclose(serial[0].lons, target[1], atol=0.1, rtol=0.0)
+    _assert_tracks_equal(serial, dask)
+
+
+@pytest.mark.integration
 def test_hodges_unique_frame_detection_count(sample_msl_dataset: xr.DataArray) -> None:
     """Verify that both serial and Dask Hodges track invocations detect each
     frame exactly once.

--- a/tests/unit/healpix/test_tracker.py
+++ b/tests/unit/healpix/test_tracker.py
@@ -14,16 +14,13 @@ def test_healpix_tracker_invalid_nside() -> None:
 
 def test_healpix_tracker_time_range() -> None:
     tracker = HealpixTracker()
-    with pytest.raises((FileNotFoundError, Exception)) as excinfo:
+    with pytest.raises(FileNotFoundError, match="nonexistent\\.nc"):
         tracker.track(
             data="nonexistent.nc",
             variable="msl",
             start_time="2025-01-01",
             end_time="2025-01-31",
         )
-    assert "nonexistent.nc" in str(excinfo.value) or isinstance(
-        excinfo.value, FileNotFoundError
-    )
 
 
 def test_healpix_preprocessing_regrids_regular_data() -> None:

--- a/tests/unit/hodges/test_detector.py
+++ b/tests/unit/hodges/test_detector.py
@@ -22,6 +22,7 @@ from pystormtracker.hodges.detector import (
 )
 from pystormtracker.hodges.tracker import HodgesFeatureRefinement, HodgesTracker
 from pystormtracker.io.data_loader import DataLoader
+from pystormtracker.models.geo import geod_dist
 from pystormtracker.refinement.bspline import BsplineRefinementResult
 
 
@@ -121,6 +122,7 @@ def test_hodges_detector_detect_mock(mock_open: MagicMock) -> None:
 
 def test_hodges_detector_from_xarray_keeps_generic_detection_values() -> None:
     values = np.ones((1, 5, 5), dtype=np.float64)
+    values[0, 1:4, 1:4] = -0.5
     values[0, 2, 2] = -1.0
     data = xr.DataArray(
         values,
@@ -153,6 +155,107 @@ def test_hodges_detector_from_xarray_keeps_generic_detection_values() -> None:
     np.testing.assert_array_equal(result.diagnostics["raw_value"], np.array([-1.0]))
     assert result.diagnostic_units["raw_value"] is None
     assert result.diagnostic_units["object_gridcell_area_km2"] == "km2"
+    assert result.diagnostics["object_gridcell_area_km2"][0] > 0.0
+    for name in (
+        "object_moment_fitted_area_km2",
+        "object_moment_major_axis_km",
+        "object_moment_minor_axis_km",
+        "object_moment_orientation_degrees",
+    ):
+        assert np.isfinite(result.diagnostics[name]).all()
+
+
+def test_quadratic_detection_refines_a_nonempty_object_and_reports_properties() -> None:
+    latitudes = np.arange(9.0)
+    longitudes = np.arange(9.0)
+    lon_grid, lat_grid = np.meshgrid(longitudes, latitudes)
+    target_latitude = 3.2
+    target_longitude = 4.3
+    frame = (
+        1000.0 - (lat_grid - target_latitude) ** 2 - (lon_grid - target_longitude) ** 2
+    )
+
+    result, diagnostics = detect_hodges_frame(
+        frame,
+        np.datetime64("2025-12-01"),
+        latitudes,
+        longitudes,
+        intensity_threshold=990.0,
+        mode="max",
+        min_grid_points=3,
+        feature_refinement="quadratic",
+        periodic_x=False,
+    )
+
+    assert result.latitudes.size == 1
+    assert diagnostics[0].status == "success"
+    assert result.latitudes[0] == pytest.approx(target_latitude, abs=1.0e-12)
+    assert result.longitudes[0] == pytest.approx(target_longitude, abs=1.0e-12)
+    assert result.values[0] == pytest.approx(1000.0)
+    assert result.diagnostics["raw_value"][0] == pytest.approx(frame[3, 4])
+    for name in (
+        "object_gridcell_area_km2",
+        "object_moment_fitted_area_km2",
+        "object_moment_major_axis_km",
+        "object_moment_minor_axis_km",
+        "object_moment_orientation_degrees",
+    ):
+        value = result.diagnostics[name][0]
+        assert np.isfinite(value)
+        if name != "object_moment_orientation_degrees":
+            assert value > 0.0
+
+
+def test_spherical_quadratic_detector_refines_an_analytic_global_minimum() -> None:
+    latitudes = np.linspace(-90.0, 90.0, 37, dtype=np.float64)
+    longitudes = np.arange(0.0, 360.0, 5.0, dtype=np.float64)
+    target = (32.3, 179.2)
+    lat_grid, lon_grid = np.meshgrid(latitudes, longitudes, indexing="ij")
+    target_latitude, target_longitude = np.deg2rad(target)
+    target_vector = np.array(
+        [
+            np.cos(target_latitude) * np.cos(target_longitude),
+            np.cos(target_latitude) * np.sin(target_longitude),
+            np.sin(target_latitude),
+        ]
+    )
+    points = np.stack(
+        (
+            np.cos(np.deg2rad(lat_grid)) * np.cos(np.deg2rad(lon_grid)),
+            np.cos(np.deg2rad(lat_grid)) * np.sin(np.deg2rad(lon_grid)),
+            np.sin(np.deg2rad(lat_grid)),
+        ),
+        axis=-1,
+    )
+    frame = 1.0 - points @ target_vector
+
+    result, diagnostics = detect_hodges_frame(
+        frame,
+        np.datetime64("2025-12-01"),
+        latitudes,
+        longitudes,
+        intensity_threshold=0.2,
+        mode="min",
+        min_grid_points=3,
+        feature_refinement="spherical_quadratic",
+    )
+
+    assert result.latitudes.size == 1
+    assert diagnostics[0].status == "success"
+    initial_error = geod_dist(
+        diagnostics[0].grid_latitude,
+        diagnostics[0].grid_longitude,
+        *target,
+    )
+    refined_error = geod_dist(
+        float(result.latitudes[0]),
+        float(result.longitudes[0]),
+        *target,
+    )
+    assert refined_error < initial_error
+    assert np.rad2deg(refined_error) < 0.01
+    assert abs(result.latitudes[0] - target[0]) < 5.0
+    assert abs((result.longitudes[0] - target[1] + 180.0) % 360.0 - 180.0) < 5.0
 
 
 def test_spherical_spline_refines_synthetic_gaussian_depression() -> None:
@@ -189,6 +292,17 @@ def test_spherical_spline_refines_synthetic_gaussian_depression() -> None:
     assert result.latitudes.tolist() == pytest.approx([target_latitude], abs=0.1)
     assert result.longitudes.tolist() == pytest.approx([target_longitude], abs=0.1)
     assert detector.last_refinement_diagnostics[0].status == "success"
+    for name in (
+        "object_gridcell_area_km2",
+        "object_moment_fitted_area_km2",
+        "object_moment_major_axis_km",
+        "object_moment_minor_axis_km",
+        "object_moment_orientation_degrees",
+    ):
+        value = result.diagnostics[name][0]
+        assert np.isfinite(value)
+        if name != "object_moment_orientation_degrees":
+            assert value > 0.0
 
 
 def test_track_smoopy_uses_source_surviving_periodic_endpoint(
@@ -489,7 +603,7 @@ def test_ccl_does_not_join_projected_x_boundaries() -> None:
     assert projected_objects == 2
 
 
-def test_ccl_matches_track_vertex_and_edge_connectivity() -> None:
+def test_ccl_uses_track_vertex_connectivity() -> None:
     frame = np.zeros((4, 4), dtype=np.float64)
     frame[0, 0] = 1.0
     frame[1, 1] = 1.0
@@ -497,27 +611,12 @@ def test_ccl_matches_track_vertex_and_edge_connectivity() -> None:
     vertex_labels, vertex_count = _label_connected_components(
         frame, threshold=0.5, is_min=False, periodic_x=False
     )
-    edge_labels, edge_count = _label_connected_components(
-        frame,
-        threshold=0.5,
-        is_min=False,
-        periodic_x=False,
-        vertex_connectivity=False,
-    )
 
     assert vertex_count == 1
     np.testing.assert_array_equal(
         vertex_labels,
         np.array(
             [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
-            dtype=np.int32,
-        ),
-    )
-    assert edge_count == 2
-    np.testing.assert_array_equal(
-        edge_labels,
-        np.array(
-            [[1, 0, 0, 0], [0, 2, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]],
             dtype=np.int32,
         ),
     )

--- a/tests/unit/hodges/test_mge.py
+++ b/tests/unit/hodges/test_mge.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from pystormtracker.hodges.mge import (
     _compute_adaptive_phimax,
+    _mge_iteration,
     _select_regional_dmax,
     geod_dev,
 )
@@ -79,3 +80,96 @@ def test_compute_adaptive_phimax() -> None:
     # Interpolated
     # Between 1.0 and 2.0, mean is 1.5 -> (1.0 + 0.3)/2 = 0.65
     assert np.allclose(_compute_adaptive_phimax(1.5, adaptive_smoothness, 0.5), 0.65)
+
+
+def test_mge_iteration_accepts_a_beneficial_swap_and_restores_scan_state() -> None:
+    tracks = np.array([[0, 2, 5], [1, 3, 4]], dtype=np.int64)
+    original = tracks.copy()
+    features_lat = np.zeros(6, dtype=np.float64)
+    features_lon = np.array([0.0, 10.0, 1.0, 9.0, 2.0, 8.0], dtype=np.float64)
+
+    result = _mge_iteration(
+        tracks,
+        features_lat,
+        features_lon,
+        1,
+        True,
+        0.5,
+        0.5,
+        np.array([20.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        np.zeros(3, dtype=np.int64),
+        np.empty((0, 5), dtype=np.float64),
+        np.zeros((2, 0), dtype=np.float64),
+    )
+
+    assert result == (0, 1)
+    np.testing.assert_array_equal(tracks, original)
+
+
+def test_mge_iteration_rejects_a_swap_over_the_displacement_limit() -> None:
+    tracks = np.array([[0, 2, 5], [1, 3, 4]], dtype=np.int64)
+    features_lat = np.zeros(6, dtype=np.float64)
+    features_lon = np.array([0.0, 10.0, 1.0, 9.0, 8.0, 2.0], dtype=np.float64)
+
+    result = _mge_iteration(
+        tracks,
+        features_lat,
+        features_lon,
+        1,
+        True,
+        0.5,
+        0.5,
+        np.array([5.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        np.zeros(3, dtype=np.int64),
+        np.empty((0, 5), dtype=np.float64),
+        np.zeros((2, 0), dtype=np.float64),
+    )
+
+    assert result == (-1, -1)
+
+
+def test_mge_iteration_rejects_a_swap_over_adaptive_smoothness_limit() -> None:
+    tracks = np.array([[0, 2, 5], [1, 3, 4]], dtype=np.int64)
+    features_lat = np.array([0.0, 0.0, 0.0, 0.0, 2.0, -2.0], dtype=np.float64)
+    features_lon = np.array([0.0, 10.0, 2.0, 8.0, 4.0, 2.0], dtype=np.float64)
+    dmax_parameters = np.array([10.0], dtype=np.float64)
+    phimax_parameters = np.array([1.0], dtype=np.float64)
+    missing_counts = np.zeros(3, dtype=np.int64)
+    zones = np.empty((0, 5), dtype=np.float64)
+
+    beneficial_without_adaptation = _mge_iteration(
+        tracks.copy(),
+        features_lat,
+        features_lon,
+        1,
+        True,
+        0.5,
+        0.5,
+        dmax_parameters,
+        phimax_parameters,
+        missing_counts,
+        zones,
+        np.zeros((2, 0), dtype=np.float64),
+    )
+    rejected_with_adaptation = _mge_iteration(
+        tracks.copy(),
+        features_lat,
+        features_lon,
+        1,
+        True,
+        0.5,
+        0.5,
+        dmax_parameters,
+        phimax_parameters,
+        missing_counts,
+        zones,
+        np.array(
+            [[0.0, 10.0, 20.0, 30.0], [0.05, 0.05, 0.05, 0.05]],
+            dtype=np.float64,
+        ),
+    )
+
+    assert beneficial_without_adaptation == (0, 1)
+    assert rejected_with_adaptation == (-1, -1)


### PR DESCRIPTION
## Summary

- Expand unit and integration coverage for Hodges detection, object properties, MGE constraints, Healpix tracking, and parallel backends.
- Add regression coverage for planar and spherical quadratic feature refinement, including analytic minima and serial–Dask equivalence.
- Run integration and parity coverage jobs on selected CI runners, with isolated Numba coverage caches.

## Why

These tests protect scientific behavior and backend equivalence that were previously under-covered, including spherical feature refinement, TRACK vertex connectivity, adaptive MGE constraints, and diagnostic object-property calculations. CI coverage is now collected from representative integration and parity jobs.

## Validation

- Focused tests: 38 passed, including the four-rank MPI integration test.
- [GitHub Actions CI run passed](https://github.com/mwyau/PyStormTracker/actions/runs/32788578993).
- CI workflow updated to collect coverage for integration and parity test jobs.