### PR TITLE
fix(io): avoid logging input paths

### DIFF
--- a/src/pystormtracker/io/data_loader.py
+++ b/src/pystormtracker/io/data_loader.py
@@ -243,8 +243,7 @@ class DataLoader:
 
                 self._ds = self._ds_cache[cache_key]
                 LOGGER.debug(
-                    "Opened input %r with engine=%s chunks=%r dims=%s",
-                    self.pathname,
+                    "Opened input with engine=%s chunks=%r dims=%s",
                     engine,
                     self.chunks,
                     dict(self._ds.sizes),


### PR DESCRIPTION
## Summary

- stop writing `DataLoader.pathname` to debug logs
- retain non-sensitive diagnostics: selected engine, chunking, and dataset dimensions
- preserve all data-loading behavior

## Security

Fixes CodeQL code-scanning alert #6 (`py/clear-text-logging-sensitive-data`). `pathname` may contain local usernames/private directories or remote URL credentials/query parameters, so it is omitted rather than partially redacted.

## Validation

- change is limited to `src/pystormtracker/io/data_loader.py`
- branch was reset to current `main` (`be57dd67`) before applying the corrected fix
- CodeQL/default setup will rescan the Python data flow on this PR
