### PR TITLE
fix(io): avoid logging input paths

### DIFF
--- a/src/pystormtracker/io/data_loader.py
+++ b/src/pystormtracker/io/data_loader.py
@@ -243,8 +243,7 @@ class DataLoader:
 
                 self._ds = self._ds_cache[cache_key]
                 LOGGER.debug(
-                    "Opened input %r with engine=%s chunks=%r dims=%s",
-                    self.pathname,
+                    "Opened input with engine=%s chunks=%r dims=%s",
                     engine,
                     self.chunks,
                     dict(self._ds.sizes),


### PR DESCRIPTION
## Summary

- Stop including the input path or URL in `DataLoader` debug logging while retaining engine, chunk, and dimension diagnostics.

## Why

- CodeQL flags the pathname as sensitive data; local paths and remote URLs can expose system or credential information.

## Validation

- [x] Verified the branch contains only the intended logging change.
- [ ] CI and CodeQL
