### PR TITLE
ci: standardize MPI setup and coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             }'
             INTEGRATION_MATRIX='{
               "include": [
-                {"os": "ubuntu-26.04", "python-version": "3.14", "coverage": true}
+                {"os": "ubuntu-26.04", "python-version": "3.14", "mpi": "mpich", "coverage": true}
               ]
             }'
             PARITY_MATRIX='{
@@ -73,10 +73,10 @@ jobs:
             }'
             INTEGRATION_MATRIX='{
               "include": [
-                {"os": "ubuntu-26.04-arm", "python-version": "3.14", "coverage": false},
-                {"os": "ubuntu-24.04", "python-version": "3.14", "coverage": true},
-                {"os": "windows-2025", "python-version": "3.13", "coverage": false},
-                {"os": "macos-26", "python-version": "3.14", "coverage": false}
+                {"os": "ubuntu-26.04-arm", "python-version": "3.14", "mpi": "mpich", "coverage": false},
+                {"os": "ubuntu-24.04", "python-version": "3.14", "mpi": "mpich", "coverage": true},
+                {"os": "windows-2025", "python-version": "3.13", "mpi": "msmpi", "coverage": false},
+                {"os": "macos-26", "python-version": "3.14", "mpi": "mpich", "coverage": false}
               ]
             }'
             PARITY_MATRIX='{
@@ -249,11 +249,10 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up Microsoft MPI on Windows
-        if: runner.os == 'Windows'
+      - name: Set up MPI
         uses: mpi4py/setup-mpi@v1.4.4
         with:
-          mpi: msmpi
+          mpi: ${{ matrix.mpi }}
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras
@@ -297,12 +296,6 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up Microsoft MPI on Windows
-        if: runner.os == 'Windows'
-        uses: mpi4py/setup-mpi@v1.4.4
-        with:
-          mpi: msmpi
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,12 @@
 # Codecov configuration
-# This config disables status checks so Codecov only reports coverage
-# but never fails the build.
+# This config enforces an overall project coverage floor while leaving patch
+# coverage status disabled.
 
 coverage:
   status:
-    project: off
+    project:
+      default:
+        target: 70%
     patch: off
 
 comment:


### PR DESCRIPTION
## Summary

<!-- What changed, and the user or developer impact. -->

- Pin `mpi4py/setup-mpi@v1.4.4` for every integration matrix platform, using MPICH on Linux/macOS and MS-MPI on Windows.
- Add a 70% overall Codecov project coverage floor while keeping patch coverage disabled.
- Remove the dead Windows-only MPI setup from parity tests.

## Why

<!-- Why this change is needed. For fixes, describe the root cause. -->

- The integration MPI test previously depended on runner-provided MPI installations and could skip when `mpiexec` was unavailable.
- Explicit platform-specific MPI setup makes integration MPI testing deterministic without adding per-flag coverage requirements.

## Validation

<!-- Commands, CI jobs, datasets, or manual checks used to verify the change. -->

- [x] `uv run prek run --all-files`
- [x] `uv run --no-sync pytest -vv tests/integration/ -m "not slow and not data"` — 20 passed, 9 deselected.
- [x] Verified `test_simple_mpi_matches_serial_on_synthetic_trajectory` executed and passed.
- [x] Validated `codecov.yml` with Codecov’s YAML validator.
- [x] Confirmed the existing unit, integration, and parity coverage flags remain unchanged.
- [ ] GitHub Actions full matrix