### PR TITLE
ci: add Codecov test analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Run unit tests with coverage
         if: matrix.mode == 'coverage'
-        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Run unit tests with JIT coverage
         if: matrix.mode == 'jit-coverage'
@@ -230,6 +230,16 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload test results
+        if: ${{ !cancelled() && matrix.mode == 'coverage' }}
+        uses: codecov/codecov-action@v7.0.0
+        with:
+          files: ./junit.xml
+          disable_search: true
+          report_type: test_results
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   integration-tests:
     name: Integration tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
     needs: [select-test-matrix, code-quality]
@@ -262,7 +272,7 @@ jobs:
         env:
           NUMBA_JIT_COVERAGE: '1'
           NUMBA_CACHE_DIR: ${{ runner.temp }}/numba-coverage-cache
-        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml tests/integration/ -m "not slow and not data"
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests/integration/ -m "not slow and not data"
 
       - name: Run integration tests
         if: matrix.coverage == false
@@ -276,6 +286,16 @@ jobs:
           disable_search: true
           flags: integration
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results
+        if: ${{ !cancelled() && matrix.coverage == true }}
+        uses: codecov/codecov-action@v7.0.0
+        with:
+          files: ./junit.xml
+          disable_search: true
+          report_type: test_results
+          flags: integration
           token: ${{ secrets.CODECOV_TOKEN }}
 
   parity-tests:
@@ -305,7 +325,7 @@ jobs:
         env:
           NUMBA_JIT_COVERAGE: '1'
           NUMBA_CACHE_DIR: ${{ runner.temp }}/numba-coverage-cache
-        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml tests/parity/ -m "not slow and not data"
+        run: uv run --no-sync pytest -vv --cov=pystormtracker --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy tests/parity/ -m "not slow and not data"
 
       - name: Run parity tests
         if: matrix.coverage == false
@@ -319,6 +339,16 @@ jobs:
           disable_search: true
           flags: parity
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results
+        if: ${{ !cancelled() && matrix.coverage == true }}
+        uses: codecov/codecov-action@v7.0.0
+        with:
+          files: ./junit.xml
+          disable_search: true
+          report_type: test_results
+          flags: parity
           token: ${{ secrets.CODECOV_TOKEN }}
 
   package-tests:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,10 @@
 # This config enforces an overall project coverage floor while leaving patch
 # coverage status disabled.
 
+codecov:
+  notify:
+    after_n_builds: 5
+
 coverage:
   status:
     project:
@@ -13,3 +17,4 @@ comment:
   layout: "reach,diff,flags,files"
   behavior: default
   require_changes: false
+  after_n_builds: 5


### PR DESCRIPTION
## Summary

Add Codecov Test Analytics reporting for the representative unit, integration, and parity test lanes.

* generate JUnit XML alongside the existing coverage reports
* upload test results with `codecov/codecov-action@v7`
* separate unit, integration, and parity results with Codecov flags
* upload results even when pytest fails so failures and flaky tests can be analyzed
* keep Test Analytics uploads non-blocking
* avoid duplicate uploads from JIT variants and the broader OS/Python matrix

## Motivation

Coverage shows which code is exercised, but it does not show test reliability or performance over time. Test Analytics adds test-duration and failure history and can help identify flaky or increasingly slow tests.

The existing representative coverage lanes provide one stable result for each suite without adding another test run or increasing the CI matrix.

## Validation

<!-- Commands, CI jobs, datasets, or manual checks used to verify the change. -->

- \[ \]
