### PR TITLE
ci: validate distributions in publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,6 @@ jobs:
         run: .sdist-venv/bin/python -c 'import pystormtracker; print("sdist import success")'
 
       - name: Upload release distributions
-        if: github.ref_type == 'tag'
         uses: actions/upload-artifact@v7
         with:
           name: release-dists

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,41 @@ permissions:
   contents: read
 
 jobs:
+  validate:
+    name: Validate distributions
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-26.04
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Retrieve tested distributions
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: release-dists
+          path: dist/
+          run-id: >-
+            ${{
+              github.event_name == 'workflow_run'
+              && github.event.workflow_run.id
+              || inputs.run_id
+            }}
+          github-token: ${{ github.token }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: '0.12.1'
+          python-version: '3.14'
+
+      - name: Check distributions
+        run: uvx --from twine==7.0.0 twine check --strict dist/*
+
   publish:
+    needs: validate
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (


### PR DESCRIPTION
## Summary

- Upload `release-dists` from every CI run so the publish workflow can validate the exact built artifacts.
- Run `twine check --strict` in a read-only validation job after every successful CI run or manual dispatch.
- Keep existing wheel/sdist package checks in CI and leave PyPI/TestPyPI publish gating unchanged.

## Why

`workflow_run` creates a Python Publish run after every CI run. Running a real distribution metadata check makes successful non-release runs useful and green instead of empty/skipped, while preserving the separate PyPI Trusted Publishing workflow.

## Validation

- CI package checks, including sdist install/import, remain in CI.
- The new validation job has only `actions: read` and `contents: read` permissions and does not install or execute the downloaded package.
- Actual publishing still requires the existing release-tag conditions or an explicit manual dispatch.
- CI is rerunning for the updated commit.